### PR TITLE
Fix: hovercontainer doesn't disappear

### DIFF
--- a/app/packages/partup:client-hover-container/HoverContainer.js
+++ b/app/packages/partup:client-hover-container/HoverContainer.js
@@ -71,9 +71,9 @@ var show = function(event) {
     }
 
     // Hide the card on mouse leave
-    // $trigger.on('mouseleave', function() {
-    //     hide($trigger);
-    // });
+    $trigger.on('mouseleave', function() {
+        hide($trigger);
+    });
 };
 
 Template.HoverContainer.onRendered(function() {


### PR DESCRIPTION
Fix the bug where the hover-container (shown when hovering over a user-avatar) never disappears until route change.