### PR TITLE
Allow CORS in HTTP calls

### DIFF
--- a/app/packages/partup:server/routes/composite.js
+++ b/app/packages/partup:server/routes/composite.js
@@ -12,6 +12,7 @@ Meteor.routeComposite = function(route, callback) {
 
         // We are going to respond in JSON format
         response.setHeader('Content-Type', 'application/json');
+        response.setHeader('Access-Control-Allow-Origin', '*');
 
         return response.end(JSON.stringify(result));
     });


### PR DESCRIPTION
Allow CORS from all origins in HTTP calls on behalf of the [Part-up app](https://github.com/part-up/app) (subscriptions and methods already do that).