### PR TITLE
Partup updates comments author avatar images publication

### DIFF
--- a/app/packages/partup:lib/collections/images.js
+++ b/app/packages/partup:lib/collections/images.js
@@ -95,6 +95,23 @@ Images.findForUpdate = function(update) {
     return Images.find({_id: {'$in': images}});
 };
 
+/**
+ * Find images for the comments in an update
+ *
+ * @memberOf Images
+ * @param {Update} update
+ * @return {Mongo.Cursor}
+ */
+Images.findForUpdateComments = function(update) {
+    update = update || {};
+
+    var imageIds = (update.comments || []).map(function(comment) {
+        return comment.creator.image;
+    });
+
+    return Images.find({_id: {'$in': imageIds}});
+};
+
 Images.findForTile = function(tile) {
     return Images.find({_id: tile.image_id}, {limit: 1});
 };

--- a/app/packages/partup:server/publications/updates.js
+++ b/app/packages/partup:server/publications/updates.js
@@ -6,6 +6,7 @@ var updateChildren = [
         {find: Images.findForUser}
     ]},
     {find: Images.findForUpdate},
+    {find: Images.findForUpdateComments},
     {find: Activities.findForUpdate},
     {find: Contributions.findForUpdate, children: [
         {find: Activities.findForContribution},


### PR DESCRIPTION
Avatars of authors of comments on updates from Part-ups do actually work, due to the Supporters and Partners subscription in the Part-up sidebar. But in the app there is no such subscription. The images should be shipped with the publication for Part-up updates. For the website, this won't matter in download size or speed of any kind. It's just an insurance for the comment author avatars to appear.

It's just another publication fix like PR #396.