### PR TITLE
Fix notifications typedata

### DIFF
--- a/app/packages/partup:server/event_handlers/contributions/contributions_handler.js
+++ b/app/packages/partup:server/event_handlers/contributions/contributions_handler.js
@@ -43,7 +43,7 @@ Event.on('partups.contributions.inserted', function(userId, contribution) {
                     slug: partup.slug
                 },
                 update: {
-                    _id: updateId
+                    _id: activity.update_id
                 }
             }
         };
@@ -70,7 +70,7 @@ Event.on('partups.contributions.inserted', function(userId, contribution) {
                     slug: partup.slug
                 },
                 update: {
-                    _id: updateId
+                    _id: activity.update_id
                 }
             }
         };

--- a/app/packages/partup:server/event_handlers/contributions/contributions_handler.js
+++ b/app/packages/partup:server/event_handlers/contributions/contributions_handler.js
@@ -44,6 +44,10 @@ Event.on('partups.contributions.inserted', function(userId, contribution) {
                 },
                 update: {
                     _id: updateId
+                },
+                activity: {
+                    _id: activity._id,
+                    update_id: activity.update_id
                 }
             }
         };
@@ -71,6 +75,10 @@ Event.on('partups.contributions.inserted', function(userId, contribution) {
                 },
                 update: {
                     _id: updateId
+                },
+                activity: {
+                    _id: activity._id,
+                    update_id: activity.update_id
                 }
             }
         };

--- a/app/packages/partup:server/event_handlers/contributions/contributions_handler.js
+++ b/app/packages/partup:server/event_handlers/contributions/contributions_handler.js
@@ -44,10 +44,6 @@ Event.on('partups.contributions.inserted', function(userId, contribution) {
                 },
                 update: {
                     _id: updateId
-                },
-                activity: {
-                    _id: activity._id,
-                    update_id: activity.update_id
                 }
             }
         };
@@ -75,10 +71,6 @@ Event.on('partups.contributions.inserted', function(userId, contribution) {
                 },
                 update: {
                     _id: updateId
-                },
-                activity: {
-                    _id: activity._id,
-                    update_id: activity.update_id
                 }
             }
         };

--- a/app/packages/partup:server/event_handlers/ratings/ratings_handler.js
+++ b/app/packages/partup:server/event_handlers/ratings/ratings_handler.js
@@ -27,7 +27,7 @@ Event.on('partups.contributions.ratings.inserted', function(userId, rating) {
     if (!partup) return Log.error('Partup [' + contribution.partup_id + '] for Contribution [' + contribution._id + '] could not be found?');
 
     var activity = Activities.findOne(rating.activity_id);
-    if (!partup) return Log.error('Activity [' + rating.activity_id + '] for Rating [' + rating._id + '] could not be found?');
+    if (!activity) return Log.error('Activity [' + rating.activity_id + '] for Rating [' + rating._id + '] could not be found?');
 
     var notificationOptions = {
         userId: contributionUpper._id,

--- a/app/packages/partup:server/event_handlers/ratings/ratings_handler.js
+++ b/app/packages/partup:server/event_handlers/ratings/ratings_handler.js
@@ -26,6 +26,9 @@ Event.on('partups.contributions.ratings.inserted', function(userId, rating) {
     var partup = Partups.findOne(contribution.partup_id);
     if (!partup) return Log.error('Partup [' + contribution.partup_id + '] for Contribution [' + contribution._id + '] could not be found?');
 
+    var activity = Activities.findOne(rating.activity_id);
+    if (!partup) return Log.error('Activity [' + rating.activity_id + '] for Rating [' + rating._id + '] could not be found?');
+
     var notificationOptions = {
         userId: contributionUpper._id,
         type: 'contributions_ratings_inserted',
@@ -42,6 +45,10 @@ Event.on('partups.contributions.ratings.inserted', function(userId, rating) {
             },
             update: {
                 _id: contribution.update_id
+            },
+            activity: {
+                _id: activity._id,
+                update_id: activity.update_id
             }
         }
     };

--- a/app/packages/partup:server/event_handlers/ratings/ratings_handler.js
+++ b/app/packages/partup:server/event_handlers/ratings/ratings_handler.js
@@ -26,6 +26,9 @@ Event.on('partups.contributions.ratings.inserted', function(userId, rating) {
     var partup = Partups.findOne(contribution.partup_id);
     if (!partup) return Log.error('Partup [' + contribution.partup_id + '] for Contribution [' + contribution._id + '] could not be found?');
 
+    var activity = Activities.findOne(rating.activity_id);
+    if (!partup) return Log.error('Activity [' + rating.activity_id + '] for Rating [' + rating._id + '] could not be found?');
+
     var notificationOptions = {
         userId: contributionUpper._id,
         type: 'contributions_ratings_inserted',
@@ -41,7 +44,7 @@ Event.on('partups.contributions.ratings.inserted', function(userId, rating) {
                 slug: partup.slug
             },
             update: {
-                _id: contribution.update_id
+                _id: activity.update_id
             }
         }
     };

--- a/app/packages/partup:server/event_handlers/ratings/ratings_handler.js
+++ b/app/packages/partup:server/event_handlers/ratings/ratings_handler.js
@@ -26,9 +26,6 @@ Event.on('partups.contributions.ratings.inserted', function(userId, rating) {
     var partup = Partups.findOne(contribution.partup_id);
     if (!partup) return Log.error('Partup [' + contribution.partup_id + '] for Contribution [' + contribution._id + '] could not be found?');
 
-    var activity = Activities.findOne(rating.activity_id);
-    if (!partup) return Log.error('Activity [' + rating.activity_id + '] for Rating [' + rating._id + '] could not be found?');
-
     var notificationOptions = {
         userId: contributionUpper._id,
         type: 'contributions_ratings_inserted',
@@ -45,10 +42,6 @@ Event.on('partups.contributions.ratings.inserted', function(userId, rating) {
             },
             update: {
                 _id: contribution.update_id
-            },
-            activity: {
-                _id: activity._id,
-                update_id: activity.update_id
             }
         }
     };


### PR DESCRIPTION
Generally spoken, the conversation linked to a notification are the comments on the update from `notification.type_data.update._id`. Though, for the following notification types this is not the case.

    partups_contributions_proposed
    partups_contributions_inserted
    contributions_ratings_inserted

This fix puts these notifications back into consistency and fixes the link behind these notifications in the dropdown menu. This PR will also fix the notification-related conversation in the app for these notification types.