### PR TITLE
Re-enable css processing (minification and autoprefixer)

### DIFF
--- a/app/.meteor/packages
+++ b/app/.meteor/packages
@@ -26,7 +26,7 @@ ecmascript              # Enable ECMAScript2015+ syntax in app code
 ejson
 es5-shim                # ECMAScript 5 compatibility for older browsers.
 fastclick
-fourseven:scss
+fourseven:scss@=3.2.0
 francocatena:status
 http
 iron:router
@@ -118,7 +118,7 @@ session
 simple:rest
 spacebars
 splendido:accounts-meld
-standard-minifiers-js
+standard-minifiers
 stevezhu:lodash@3.10.1
 tap:i18n
 tmeasday:publish-counts@0.7.1

--- a/app/scss.json
+++ b/app/scss.json
@@ -1,5 +1,9 @@
 {
     "useIndex" : true,
     "indexFilePath" : "client/stylesheets/main.scss",
-    "enableAutoprefixer": true
+    "enableAutoprefixer": true,
+    "autoprefixerOptions": {
+        "browsers": ["> 1%", "last 15 versions", "ie 9"],
+        "cascade": false
+    }
 }


### PR DESCRIPTION
A while ago we removed the standard-minifiers-css package by replacing standard-minifiers by standard-minifiers-js. (standard-minifiers contains both standard-minifiers-css and standard-minifiers-js). We did that because we thought it didn't split the resulting CSS file correctly for IE9 (due to max 4095 selectors limit). But it actually does, but only in production mode.

So this pull request re-enables CSS auto-vendor-prefixing and CSS minification to improve speed and compatibility. It fully works on IE with a non-development build.