### PR TITLE
fix(forms): removed peerlibrary:blaze-components package and added bl…

### DIFF
--- a/app/.meteor/packages
+++ b/app/.meteor/packages
@@ -126,4 +126,4 @@ tracker
 yogiben:autoform-tags@0.1.3
 zimme:active-route
 partup-client-admin-partups
-peerlibrary:blaze-components
+blaze-html-templates

--- a/app/.meteor/versions
+++ b/app/.meteor/versions
@@ -16,6 +16,7 @@ babel-runtime@0.1.8
 base64@1.0.8
 binary-heap@1.0.8
 blaze@2.1.7
+blaze-html-templates@1.0.4
 blaze-tools@1.0.8
 boilerplate-generator@1.0.8
 browser-policy@1.0.9
@@ -166,14 +167,8 @@ partup-newrelic@0.0.1
 partup-server@0.0.1
 pauli:accounts-linkedin@1.3.1
 pauli:linkedin@1.3.1
-peerlibrary:assert@0.2.5
 peerlibrary:aws-sdk@2.2.42_1
-peerlibrary:base-component@0.16.0
-peerlibrary:blaze-components@0.19.0
 peerlibrary:blocking@0.5.2
-peerlibrary:computed-field@0.3.1
-peerlibrary:data-lookup@0.1.0
-peerlibrary:reactive-field@0.1.0
 percolate:intercom@1.4.2
 percolate:migrations@0.9.8
 percolate:synced-cron@1.3.2


### PR DESCRIPTION
@ralphboeije @tlimpanont 

This PR fixes all the forms on part-up. I removed the package `peerlibrary:blaze-components` and reverted to  the `blaze-html-templates` package that was removed in commit 2bc2a5cc9effc740ab6ee344dd26a5c4e5934b10 (ref-media-uploader-button branch)

The issue was with the`partup-meteor-bender` page transition library that sets a 'bender-animating' class on the body width `pointer-events: none;`. This class should be removed after a page transition, but wasn't, resulting in a unusable page after any transition.