### PR TITLE
Removed Twitter share counts because api is no longer available

### DIFF
--- a/app/packages/partup-server/cron/update_shared_count.js
+++ b/app/packages/partup-server/cron/update_shared_count.js
@@ -1,4 +1,4 @@
-if(process.env.PARTUP_CRON_ENABLED) {
+if (process.env.PARTUP_CRON_ENABLED) {
     SyncedCron.add({
         name: 'Update the shared counts of a partup from different socials',
         schedule: function(parser) {
@@ -6,17 +6,15 @@ if(process.env.PARTUP_CRON_ENABLED) {
         },
         job: function() {
             if (!process.env.NODE_ENV.match(/development/)) {
-                Partups.find({}, {sort: {refreshed_at: 1}, limit: 10}).forEach(function(partup) {
+                Partups.find({}, { sort: { refreshed_at: 1 }, limit: 10 }).forEach(function(partup) {
                     var counts = {
                         facebook: Partup.server.services.shared_count.facebook(Meteor.absoluteUrl() + 'partups/' + partup.slug),
-                        twitter: Partup.server.services.shared_count.twitter(Meteor.absoluteUrl() + 'partups/' + partup.slug),
                         linkedin: Partup.server.services.shared_count.linkedin(Meteor.absoluteUrl() + 'partups/' + partup.slug)
                     };
 
                     Partups.update(partup._id, {
                         $set: {
                             'shared_count.facebook': counts.facebook,
-                            'shared_count.twitter': counts.twitter,
                             'shared_count.linkedin': counts.linkedin,
                             refreshed_at: new Date()
                         }

--- a/app/packages/partup-server/cron/update_swarm_shared_count.js
+++ b/app/packages/partup-server/cron/update_swarm_shared_count.js
@@ -1,4 +1,4 @@
-if(process.env.PARTUP_CRON_ENABLED) {
+if (process.env.PARTUP_CRON_ENABLED) {
     SyncedCron.add({
         name: 'Update the shared counts of a swarm from different socials',
         schedule: function(parser) {
@@ -6,17 +6,15 @@ if(process.env.PARTUP_CRON_ENABLED) {
         },
         job: function() {
             if (!process.env.NODE_ENV.match(/development/)) {
-                Swarms.find({}, {sort: {refreshed_at: 1}, limit: 10}).forEach(function(swarm) {
+                Swarms.find({}, { sort: { refreshed_at: 1 }, limit: 10 }).forEach(function(swarm) {
                     var counts = {
                         facebook: Partup.server.services.shared_count.facebook(Meteor.absoluteUrl() + swarm.slug),
-                        twitter: Partup.server.services.shared_count.twitter(Meteor.absoluteUrl() + swarm.slug),
                         linkedin: Partup.server.services.shared_count.linkedin(Meteor.absoluteUrl() + swarm.slug)
                     };
 
                     Swarms.update(swarm._id, {
                         $set: {
                             'shared_count.facebook': counts.facebook,
-                            'shared_count.twitter': counts.twitter,
                             'shared_count.linkedin': counts.linkedin,
                             refreshed_at: new Date()
                         }

--- a/app/packages/partup-server/services/shared_count_service.js
+++ b/app/packages/partup-server/services/shared_count_service.js
@@ -20,20 +20,6 @@ Partup.server.services.shared_count = {
         return data.shares ? data.shares : 0;
     },
 
-    twitter: function(url) {
-        var response = HTTP.get('https://cdn.api.twitter.com/1/urls/count.json?url=' + url);
-
-        if (response.statusCode !== 200) {
-            Log.error('Twitter shared count API resulted in status code [' + response.statusCode + ']', response);
-            return false;
-        }
-
-        var data = mout.object.get(response, 'data');
-        if (!data) return false;
-
-        return data.count;
-    },
-
     linkedin: function(url) {
         var response = HTTP.get('https://www.linkedin.com/countserv/count/share?format=json&url=' + url);
 


### PR DESCRIPTION
Twitter discontinued the API we used. The Search API only returns the last 7 days, so that's also not going to work.

If we want to keep this count we need to implement a Twitter Streaming API client and process the counts ourselves.

See: https://dev.twitter.com/streaming/reference/post/statuses/filter