### PR TITLE
New activities should be placed at the top of the lane

### DIFF
--- a/app/packages/partup-client-pages/app/partup/activities/activities.js
+++ b/app/packages/partup-client-pages/app/partup/activities/activities.js
@@ -29,7 +29,7 @@ Template.app_partup_activities.onCreated(function() {
 
                     return true;
                 })
-                .sort(Partup.client.sort.dateASC.bind(null, 'created_at'))
+                .sort(Partup.client.sort.dateDESC.bind(null, 'created_at'))
                 .sort(Partup.client.sort.dateASC.bind(null, 'end_date'));
 
             return activities;


### PR DESCRIPTION
I change the order to descending, now you can see the activity being added in the correct order
``` .sort(Partup.client.sort.dateDESC.bind(null, 'created_at')) ```
