### PR TITLE
fix(dropbox-chooser): Remove link expiration

### DIFF
--- a/app/packages/partup-client-dropbox-chooser/DropboxChooser.ctrl.js
+++ b/app/packages/partup-client-dropbox-chooser/DropboxChooser.ctrl.js
@@ -93,8 +93,8 @@ if (Meteor.isClient) {
                             data: JSON.stringify({
                                 path: '/' + decodeURI(path[2]),
                                 settings: {
-                                    "requested_visibility": "public",
-                                    "expires": "2045-05-12T15:50:38Z"
+                                    "requested_visibility": "public"
+                                    // "expires": "2045-05-12T15:50:38Z" --> This is only allowed for paying dropbox users.
                                 }
                             }),
                         })


### PR DESCRIPTION
According to the [api documentation](https://www.dropbox.com/developers/documentation/http/documentation#sharing-create_shared_link_with_settings) Dropbox only allows paying accounts to set an expiring date. This changes commit 69d56db

Fixes #964 