### PR TITLE
fix(dropbox-chooser): Set linkType to preview

### DIFF
--- a/app/packages/partup-client-dropbox-chooser/DropboxChooser.ctrl.js
+++ b/app/packages/partup-client-dropbox-chooser/DropboxChooser.ctrl.js
@@ -31,7 +31,7 @@ if (Meteor.isClient) {
                     success: function (files) {
                         onFileChange.apply(Dropbox, [files, dropboxClient]);
                     },
-                    linkType: "direct", // or "preview"
+                    linkType: "preview", // or "direct"
                     multiselect: true, // or true
                     extensions: getExtensions()
                 });


### PR DESCRIPTION
Dropbox direct links expire after four hours, switched to preview links. 