### PR TITLE
fix(marketo): Change handle accept event

### DIFF
--- a/app/packages/partup-client-base/marketo.js
+++ b/app/packages/partup-client-base/marketo.js
@@ -28,8 +28,12 @@ const marketo = {
 };
 
 Tracker.autorun((computation) => {
-    if ((Cookies.get('cb-enabled') === 'enabled' || Session.get('cookiesEnabled') === 'enabled') && !marketo.loaded) {
+    if (Cookies.get('cb-enabled') === 'enabled' && !marketo.loaded) {
         $(window).on('load', marketo.loadScript);
+        computation.stop();
+    }
+    if (Session.get('cookiesEnabled') === 'enabled' && !marketo.loaded) {
+        marketo.loadScript()
         computation.stop();
     }
 });


### PR DESCRIPTION
- If the user accepted after the window was loaded the window.onload event already fired and thus never triggering the marketto script;

Fixes: #1038