### PR TITLE
Fix My Tribes menu

### DIFF
--- a/app/packages/partup-client-dropdowns/tribes/tribes.html
+++ b/app/packages/partup-client-dropdowns/tribes/tribes.html
@@ -1,6 +1,7 @@
 <template name="DropdownTribes">
-    <button class="pu-button pu-button-header pu-button-avatar pu-button-header-profiledropdown {{# if menuOpen }}pu-button-header-profiledropdown-active{{/ if }}" data-toggle-menu="tribes">
-        {{_ 'mytribes-button-menu' }} {{#unless menuOpen}}<i class="picon-caret-slim-down"></i>{{/unless}}{{#if menuOpen}}<i class="picon-caret-slim-up"></i>{{/if}}
+    <button class="pu-button pu-button-header pu-button-avatar pu-button-header-profiledropdown {{#if menuOpen}}pu-button-header-profiledropdown-active{{/if}}" data-toggle-menu="tribes">
+        {{_ 'mytribes-button-menu' }} <i class="picon-caret-slim{{#if menuOpen}}-up{{else}}-down{{/if}}"></i>
+        <!--{{#unless menuOpen}}<i class="picon-caret-slim-down"></i>{{/unless}}{{#if menuOpen}}<i class="picon-caret-slim-up"></i>{{/if}}-->
     </button>
     <div class="pu-dropdown pu-dropdown-profile pu-profilemenu {{#if menuOpen}}pu-dropdown-active{{/if}}" data-clickoutside-close>
         <span class="background" data-before></span>
@@ -12,7 +13,7 @@
                     <li class='pu-dropdownitem {{#if showPartups}}{{#if partupEquals currentTribe _id}}pu-dropdownitem-active{{/if}}{{/if}}'>
                         <!-- <div class="pu-extended-hover__container" data-outer> -->
                         <div>
-                            <a href="{{ pathFor 'network' slug=slug query='show=false' }}" data-hover="{{ _id }}" >
+                            <a href="{{#if isMemberOfNetwork .}}{{ pathFor 'network' slug=slug query='show=false' }}{{else}}{{ pathFor 'network' slug=slug query='show=true' }}{{/if}}" data-hover="{{ _id }}" >
                                 <figure class="pu-avatar pu-avatar-square" style="{{# with partupGetImageUrl imageObject '80x80'}}background-image:url('{{ . }}');{{/ with}}"></figure>
                                 <span>{{ name }}</span>
                             </a>
@@ -20,19 +21,6 @@
                         <!-- <div class="pu-extended-hover__extend" data-inner></div> -->
                     </li>
                 {{/each}}
-                {{#if hasPartupsWithoutNetwork}}
-                    <!-- <li class='pu-dropdownitem pu-extended-hover {{#if showPartups}}{{#if partupEquals currentTribe "none"}}pu-dropdownitem-active{{/if}}{{/if}}' data-hohover> -->
-                    <li class='pu-dropdownitem {{#if showPartups}}{{#if partupEquals currentTribe "none"}}pu-dropdownitem-active{{/if}}{{/if}}'>
-                        <!-- <div class="pu-extended-hover__container" data-outer> -->
-                        <div>
-                            <a data-hover="none" class="noclick">
-                                <figure class="pu-avatar pu-avatar-square" style="background-image:url('../images/other-partups.svg');"></figure>
-                                <span>Other part-ups</span>
-                            </a>
-                        </div>
-                        <!-- <div class="pu-extended-hover__extend" data-inner></div> -->
-                    </li>
-                {{/if}}
             </ul>
             <footer>
                 <a href="{{pathFor 'discover'}}">{{_ 'mytribes-button-discover' }}</a>

--- a/app/packages/partup-client-dropdowns/tribes/tribes.js
+++ b/app/packages/partup-client-dropdowns/tribes/tribes.js
@@ -188,7 +188,7 @@ Template.DropdownTribes.helpers({
     loadingSupporterpartups: () => Template.instance().states.loadingSupporterpartups.get(),
 
     networks: () => Template.instance().results.networks.get(),
-    isMemberOfNetwork: network => network.uppers.find(user => user._id === Meteor.userId()),
+    isMemberOfNetwork: network => network.uppers.find(userId => userId === Meteor.userId()),
 
     upperPartups: () => {
         let user = Meteor.user()

--- a/app/packages/partup-lib/collections/users.js
+++ b/app/packages/partup-lib/collections/users.js
@@ -412,11 +412,41 @@ User = function(user) {
             }
         },
 
+        /**
+         * Check if the user is a partner in a partup
+         * @name isPartnerInPartup
+         * @member {Function}
+         * @return {Boolean}
+         */
         isPartnerInPartup: function(partupId) {
             var upperOf = user.upperOf || [];
             return upperOf.indexOf(partupId) > -1;
         },
 
+        /**
+         * Check if the user is a supporter in a partup
+         * @name isSupporterInPartup
+         * @member {Function}
+         * @param {Integer} partupId
+         * @return {Boolean}
+         */
+        isSupporterInPartup: partupId => (user.supporterOf || []).indexOf(partupId) > -1,
+
+        /**
+         * Check if the user is partner or supporter in a partup
+         * @name isPartnerOrSupporterInPartup
+         * @member {Function}
+         * @param {Integer} partupId
+         * @return {Boolean}
+         */
+        isPartnerOrSupporterInPartup: partupId => isPartnerInPartup(partupId) | isSupporterInPartup(partupId),
+    
+        /**
+         * Check if the user is member of any partup
+         * @name isMemberOfAnyPartup
+         * @member {Function}
+         * @return {Boolean}
+         */
         isMemberOfAnyPartup: function() {
             if (!user) return false;
             var upperOf = user.upperOf || [];
@@ -426,6 +456,11 @@ User = function(user) {
             return isSupporter || isPartner;
         },
 
+        /**
+         * Check if the user is member of any network
+         * @member {Function}
+         * @return {Boolean}
+         */
         isMemberOfAnyNetwork: function() {
             if (!user) return false;
 


### PR DESCRIPTION
The Networks the user was not a member of were not shown, even if the user was partner or supporter in one of it's partups. The My Tribes menu now loads all networks related to partups where the user is partner or supporter. 
 
**Testcase**:
1. Login as judy@ and click the My Tribes menu;
2. You should see 2 tribes, ING and Lifely;
3. Judy is not a member of ING, should go to the landing page on click;
4. Judy is a member of Lifely, should go to the partup overview page on click;

**_Not tested_**: The user is associated with many partups within a couple of networks and loading takes longer than 3 seconds. Since the technique to load the networks has changed a race condition may occur.

Closes: #1050 