### PR TITLE
feat(invite-modal): Make invite button visible for first tiles

### DIFF
--- a/app/client/stylesheets/components/_pu-page.scss
+++ b/app/client/stylesheets/components/_pu-page.scss
@@ -179,20 +179,24 @@
 
     &-invitemodal {
         .pu-sub-pagecontent {
-            // padding: 36px 0;
             padding-top:15px;
         }
 
-        .pu-title-modal {
-            margin-bottom: 0;
+        .pu-wrap-modal {
+            .pu-title-modal {
+                margin-bottom: 0;
+            }
+            .pu-description-modal {
+                margin-bottom: 0px;
+            }
         }
 
-        .pu-description-modal {
-            margin-bottom: 0px + 3px;
+        .pu-invite-suggestions-label {
+            margin-top:0px;
         }
 
         .pu-filterbar {
-            margin-bottom: 20px - 2px;
+            margin-bottom: 12px;
         }
     }
 
@@ -212,7 +216,6 @@
 
     @media screen and (min-width: $breakpoint-desktop) {
         .pu-sub-pagecontent {
-            // padding-top: 70px;
             padding-top:20px;
         }
 

--- a/app/client/stylesheets/components/_pu-page.scss
+++ b/app/client/stylesheets/components/_pu-page.scss
@@ -179,7 +179,8 @@
 
     &-invitemodal {
         .pu-sub-pagecontent {
-            padding: 36px 0;
+            // padding: 36px 0;
+            padding-top:15px;
         }
 
         .pu-title-modal {
@@ -211,7 +212,8 @@
 
     @media screen and (min-width: $breakpoint-desktop) {
         .pu-sub-pagecontent {
-            padding-top: 70px;
+            // padding-top: 70px;
+            padding-top:20px;
         }
 
         &-error {

--- a/app/packages/partup-client-pages/modal/invite_to_activity/invite_to_activity.html
+++ b/app/packages/partup-client-pages/modal/invite_to_activity/invite_to_activity.html
@@ -11,7 +11,9 @@
             <div class="pu-wrap pu-wrap-modal">
 
                 <h2 class="pu-title pu-title-modal">{{_ 'pages-modal-invite_to_activity-title'}}</h2>
-                <p class="pu-description-modal">{{_ 'pages-modal-invite_to_activity-explanation'}}</p>
+                {{#if screenSizeIsMinimalWidth 'desktop'}}
+                    <p class="pu-description-modal">{{_ 'pages-modal-invite_to_activity-explanation'}}</p>
+                {{/if}}
 
                 {{#TabView onToggleTab=onToggleTab defaultActiveTab=1 }}
                     <nav class="pu-navigation pu-navigation-header pu-navigation-tabs"> 

--- a/app/packages/partup-client-pages/modal/invite_to_partup/invite_to_partup.html
+++ b/app/packages/partup-client-pages/modal/invite_to_partup/invite_to_partup.html
@@ -10,7 +10,9 @@
         <div class="pu-sub-pagecontent">
             <div class="pu-wrap pu-wrap-modal">
                 <h2 class="pu-title pu-title-modal">{{_ 'pages-modal-invite_to_partup-title'}}</h2>
-                <p class="pu-description-modal">{{_ 'pages-modal-invite_to_partup-explanation'}}</p>
+                {{#if screenSizeIsMinimalWidth 'desktop'}}
+                    <p class="pu-description-modal">{{_ 'pages-modal-invite_to_partup-explanation'}}</p>
+                {{/if}}
                 {{#TabView onToggleTab=hooks.onToggleTab defaultActiveTab=1 }}
                     <nav class="pu-navigation pu-navigation-header pu-navigation-tabs">
                         <ul class="pu-list pu-list-horizontal">

--- a/app/packages/partup-client-pages/modal/network/network-invite.html
+++ b/app/packages/partup-client-pages/modal/network/network-invite.html
@@ -11,7 +11,9 @@
             <section class="pu-wrap pu-wrap-modal">
 
                 <h2 class="pu-title pu-title-modal">{{_ "pages-modal-network_invite-title" }}</h2>
-                <p class="pu-description-modal">{{_ "pages-modal-network_invite-description" }}</p>
+                {{#if screenSizeIsMinimalWidth 'desktop'}}
+                    <p class="pu-description-modal">{{_ "pages-modal-network_invite-description" }}</p>
+                {{/if}}
                 {{# TabView onToggleTab=hooks.onToggleTab defaultActiveTab=1 }}
                     <nav class="pu-navigation pu-navigation-header pu-navigation-tabs">
                         <ul class="pu-list pu-list-horizontal">


### PR DESCRIPTION
- Lower padding-top for page
- Only display description on desktop screens

As my screen shows the tiles by default I can not test if what I did helped, ***please check if the invite button is now visible on macbooks before accepting the request.***

#1055