### PR TITLE
fix(toggle-notifications): Change wrapper from button to div

### DIFF
--- a/app/client/stylesheets/components/compositions/_pu-composition-profilesettings-email.scss
+++ b/app/client/stylesheets/components/compositions/_pu-composition-profilesettings-email.scss
@@ -10,5 +10,9 @@
 
     .pu-switch {
         width: 100%;
+
+        .align-right {
+            float:right;
+        }
     }
 }

--- a/app/packages/partup-client-dropdowns/notifications/notifications.js
+++ b/app/packages/partup-client-dropdowns/notifications/notifications.js
@@ -1,5 +1,6 @@
 Template.DropdownNotifications.onCreated(function() {
     var template = this;
+    
     template.dropdownOpen = new ReactiveVar(false, function(a, b) {
         if (a === b || b) return;
 

--- a/app/packages/partup-client-pages/modal/profile_settings/notifications/notifications.html
+++ b/app/packages/partup-client-pages/modal/profile_settings/notifications/notifications.html
@@ -7,100 +7,100 @@
             <li>
                 <div class="pu-switch {{#if email.dailydigest}}pu-switch-enabled{{else}}pu-switch-disabled{{/if}}">
                     <span>{{_ 'modal-profilesettings-email-dailydigest' }}</span>
-                    <button type="button">
+                    <div class="align-right">
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-confirm" data-enable="dailydigest"> <i class="picon-check"></i> </div>
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-deny" data-disable="dailydigest"> <i class="picon-times"></i> </div>
-                    </button>
+                    </div>
                 </div>
             </li>
             <li>
                 <div class="pu-switch {{#if email.upper_mentioned_in_partup}}pu-switch-enabled{{else}}pu-switch-disabled{{/if}}">
                     <span>{{_ 'modal-profilesettings-email-upper_mentioned_in_partup' }}</span>
-                    <button type="button">
+                    <div class="align-right">
                         <div type="button" class="pu-button pu-button-checkmark pu-button-checkmark-confirm" data-enable="upper_mentioned_in_partup"> <i class="picon-check"></i> </div>
                         <div type="button" class="pu-button pu-button-checkmark pu-button-checkmark-deny" data-disable="upper_mentioned_in_partup"> <i class="picon-times"></i> </div>
-                    </button>
+                    </div>
                 </div>
             </li>
             <li>
                 <div class="pu-switch {{#if email.upper_mentioned_in_network_chat}}pu-switch-enabled{{else}}pu-switch-disabled{{/if}}">
                     <span>{{_ 'modal-profilesettings-email-upper_mentioned_in_network_chat' }}</span>
-                    <button type="button">
+                    <div class="align-right">
                         <div type="button" class="pu-button pu-button-checkmark pu-button-checkmark-confirm" data-enable="upper_mentioned_in_network_chat"> <i class="picon-check"></i> </div>
                         <div type="button" class="pu-button pu-button-checkmark pu-button-checkmark-deny" data-disable="upper_mentioned_in_network_chat"> <i class="picon-times"></i> </div>
-                    </button>
+                    </div>
                 </div>
             </li>
             <li>
                 <div class="pu-switch {{#if email.invite_upper_to_partup}}pu-switch-enabled{{else}}pu-switch-disabled{{/if}}">
                     <span>{{_ 'modal-profilesettings-email-invite_upper_to_partup' }}</span>
-                    <button type="button">
+                    <div class="align-right">
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-confirm" data-enable="invite_upper_to_partup"> <i class="picon-check"></i> </div>
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-deny" data-disable="invite_upper_to_partup"> <i class="picon-times"></i> </div>
-                    </button>
+                    </div>
                 </div>
             </li>
             <li>
                 <div class="pu-switch {{#if email.invite_upper_to_partup_activity}}pu-switch-enabled{{else}}pu-switch-disabled{{/if}}">
                     <span>{{_ 'modal-profilesettings-email-invite_upper_to_partup_activity' }}</span>
-                    <button type="button">
+                    <div class="align-right">
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-confirm" data-enable="invite_upper_to_partup_activity"> <i class="picon-check"></i> </div>
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-deny" data-disable="invite_upper_to_partup_activity"> <i class="picon-times"></i> </div>
-                    </button>
+                    </div>
                 </div>
             </li>
             <li>
                 <div class="pu-switch {{#if email.invite_upper_to_network}}pu-switch-enabled{{else}}pu-switch-disabled{{/if}}">
                     <span>{{_ 'modal-profilesettings-email-invite_upper_to_network' }}</span>
-                    <button type="button">
+                    <div class="align-right">
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-confirm" data-enable="invite_upper_to_network"> <i class="picon-check"></i> </div>
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-deny" data-disable="invite_upper_to_network"> <i class="picon-times"></i> </div>
-                    </button>
+                    </div>
                 </div>
             </li>
             <li>
                 <div class="pu-switch {{#if email.partup_created_in_network}}pu-switch-enabled{{else}}pu-switch-disabled{{/if}}">
                     <span>{{_ 'modal-profilesettings-email-partup_created_in_network' }}</span>
-                    <button type="button">
+                    <div class="align-right">
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-confirm" data-enable="partup_created_in_network"> <i class="picon-check"></i> </div>
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-deny" data-disable="partup_created_in_network"> <i class="picon-times"></i> </div>
-                    </button>
+                    </div>
                 </div>
             </li>
             <li>
                 <div class="pu-switch {{#if email.partups_networks_accepted}}pu-switch-enabled{{else}}pu-switch-disabled{{/if}}">
                     <span>{{_ 'modal-profilesettings-email-partups_networks_accepted' }}</span>
-                    <button type="button">
+                    <div class="align-right">
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-confirm" data-enable="partups_networks_accepted"> <i class="picon-check"></i> </div>
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-deny" data-disable="partups_networks_accepted"> <i class="picon-times"></i> </div>
-                    </button>
+                    </div>
                 </div>
             </li>
             <li>
                 <div class="pu-switch {{#if email.partups_new_comment_in_involved_conversation}}pu-switch-enabled{{else}}pu-switch-disabled{{/if}}">
                     <span>{{_ 'modal-profilesettings-email-partups_new_comment_in_involved_conversation' }}</span>
-                    <button type="button">
+                    <div class="align-right">
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-confirm" data-enable="partups_new_comment_in_involved_conversation"> <i class="picon-check"></i> </div>
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-deny" data-disable="partups_new_comment_in_involved_conversation"> <i class="picon-times"></i> </div>
-                    </button>
+                    </div>
                 </div>
             </li>
             <li>
                 <div class="pu-switch {{#if email.partups_networks_new_upper}}pu-switch-enabled{{else}}pu-switch-disabled{{/if}}">
                     <span>{{_ 'modal-profilesettings-email-partups_networks_new_upper' }}</span>
-                    <button type="button">
+                    <div class="align-right">
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-confirm" data-enable="partups_networks_new_upper"> <i class="picon-check"></i> </div>
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-deny" data-disable="partups_networks_new_upper"> <i class="picon-times"></i> </div>
-                    </button>
+                    </div>
                 </div>
             </li>
             <li>
                 <div class="pu-switch {{#if email.partups_partner_request}}pu-switch-enabled{{else}}pu-switch-disabled{{/if}}">
                     <span>{{_ 'modal-profilesettings-email-partups_partner_request' }}</span>
-                    <button type="button">
+                    <div class="align-right">
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-confirm" data-enable="partups_partner_request"> <i class="picon-check"></i> </div>
                         <div class="pu-button pu-button-checkmark pu-button-checkmark-deny" data-disable="partups_partner_request"> <i class="picon-times"></i> </div>
-                    </button>
+                    </div>
                 </div>
             </li>
 
@@ -109,19 +109,19 @@
                 <li>
                     <div class="pu-switch {{#if email.partups_networks_new_pending_upper}}pu-switch-enabled{{else}}pu-switch-disabled{{/if}}">
                         <span>{{_ 'modal-profilesettings-email-partups_networks_new_pending_upper' }}</span>
-                        <button type="button">
+                        <div class="align-right">
                             <div class="pu-button pu-button-checkmark pu-button-checkmark-confirm" data-enable="partups_networks_new_pending_upper"> <i class="picon-check"></i> </div>
                             <div class="pu-button pu-button-checkmark pu-button-checkmark-deny" data-disable="partups_networks_new_pending_upper"> <i class="picon-times"></i> </div>
-                        </button>
+                        </div>
                     </div>
                 </li>
                 <li>
                     <div class="pu-switch {{#if email.partups_networks_upper_left}}pu-switch-enabled{{else}}pu-switch-disabled{{/if}}">
                         <span>{{_ 'modal-profilesettings-email-partups_networks_upper_left' }}</span>
-                        <button type="button">
+                        <div class="align-right">
                             <div class="pu-button pu-button-checkmark pu-button-checkmark-confirm" data-enable="partups_networks_upper_left"> <i class="picon-check"></i> </div>
                             <div class="pu-button pu-button-checkmark pu-button-checkmark-deny" data-disable="partups_networks_upper_left"> <i class="picon-times"></i> </div>
-                        </button>
+                        </div>
                     </div>
                 </li>
             {{/if}}


### PR DESCRIPTION
Because the wrapper was a button the browser did not recognize clicks on elements inside the button but only to the wrapper button itself. Changed the wrapper button element to a div element.

Tested on: 
WIN10: Chrome, Edge (2 devices) and IE
Linux: Chrome, FF

**Complexity**: 13
**Time**: 15 minutes

Closes #838