### PR TITLE
fix(style): Remove underline from hyperlink hover

### DIFF
--- a/app/client/stylesheets/reset.css
+++ b/app/client/stylesheets/reset.css
@@ -50,3 +50,6 @@ table {
     border-collapse: collapse;
     border-spacing: 0;
 }
+a:hover,a:focus {
+    text-decoration: none;
+}


### PR DESCRIPTION
The bootstrap.scss file had an underline on :hover, :focus. This is now countered by specifying 'none' in the reset.scss file

Fixes: #1078