### PR TITLE
fix(browser): A user joins a tribe when a partup is created by the user

### DIFF
--- a/app/packages/partup-server/methods/partups/partups_methods.js
+++ b/app/packages/partup-server/methods/partups/partups_methods.js
@@ -41,6 +41,11 @@ Meteor.methods({
             if (newPartup.network_id) {
                 var network = Networks.findOneOrFail(newPartup.network_id);
                 network.createPartupName(newPartup._id, newPartup.name);
+
+                if (!network.hasMember(user._id) && network.isPublic()) {
+                    network.addUpper(user._id);
+                    Event.emit('networks.uppers.inserted', user, network);
+                }
             }
 
             return {


### PR DESCRIPTION
If the user creates a partup in a public tribe where the user is not a member of, the user now
automatically becomes a member.

#1021