### PR TITLE
fix(babel): Remove babelrc files because meteor upgrade to 1.5

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-    "presets": ["es2015"],
-    "plugins": ["transform-es2015-destructuring", "transform-object-rest-spread"]
-}

--- a/app/.babelrc
+++ b/app/.babelrc
@@ -1,4 +1,0 @@
-{
-    "presets": ["meteor", "es2015"],
-    "plugins": ["transform-es2015-destructuring", "transform-object-rest-spread"]
-}


### PR DESCRIPTION
Meteor 1.5.1 build changes how babel should be handled. Further investigation wanted, we still have import / dependencies around the old way of handling babel.