### PR TITLE
Fix: font loading error in IE11

### DIFF
--- a/app/client/stylesheets/font-faces/_open-sans.scss
+++ b/app/client/stylesheets/font-faces/_open-sans.scss
@@ -10,11 +10,10 @@ $folder-prefix: "/fonts/open-sans";
 }
 
 @font-face {
-    $folder-style-prefix: "/regular";
+    $folder-style-prefix: "/italic";
 
     font-family: "open-sans";
-    src: url($folder-prefix + $folder-style-prefix + "/opensans-italic-webfont.eot");
-    src: url($folder-prefix + $folder-style-prefix + "/opensans-italic-webfont.eot?#iefix") format("embedded-opentype"), url($folder-prefix + $folder-style-prefix + "/opensans-italic-webfont.woff2") format("woff2"), url($folder-prefix + $folder-style-prefix + "/opensans-italic-webfont.woff") format("woff"), url($folder-prefix + $folder-style-prefix + "/opensans-italic-webfont.ttf") format("truetype");
+    src: url($folder-prefix + $folder-style-prefix + "/opensans-italic-webfont.eot?#iefix") format("embedded-opentype"), url($folder-prefix + $folder-style-prefix + "/opensans-italic-webfont.woff") format("woff"), url($folder-prefix + $folder-style-prefix + "/opensans-italic-webfont.ttf") format("truetype");
     font-weight: normal;
     font-style: italic;
 }

--- a/app/client/stylesheets/font-faces/_picons.scss
+++ b/app/client/stylesheets/font-faces/_picons.scss
@@ -1,6 +1,6 @@
 @font-face {
     font-family: "partup-icons";
-    src: url("/fonts/icons/partup-icons.woff2?v=1481721394166"), url("/fonts/icons/partup-icons.woff?v=1481721394166"), url("/fonts/icons/partup-icons.ttf?v=1481721394166");
+    src: url("/fonts/icons/partup-icons.woff2?v=1481721394166") format("woff2"), url("/fonts/icons/partup-icons.woff?v=1481721394166") format("woff"), url("/fonts/icons/partup-icons.ttf?v=1481721394166") format("truetype");
     font-weight: normal;
     font-style: normal;
 }

--- a/app/iconfont.json
+++ b/app/iconfont.json
@@ -6,6 +6,6 @@
     "classPrefix": "picon-",
     "types": [ "woff2", "woff", "ttf" ],
     "stylesheets": {
-        "stylesheets/font-faces/_picons.sass": "client/stylesheets/templates/_picons.tpl"
+        "stylesheets/font-faces/_picons.scss": "client/stylesheets/templates/_picons.tpl"
     }
 }

--- a/devops/provision/roles/loadbalancer/files/partup-maintenance/css/font-faces.css
+++ b/devops/provision/roles/loadbalancer/files/partup-maintenance/css/font-faces.css
@@ -49,13 +49,11 @@
 }
 
 @font-face {
-    $folder-style-prefix: '/regular';
     font-family: 'open-sans';
-    src: url('../fonts/open-sans/regular/opensans-italic-webfont.eot');
-    src: url('../fonts/open-sans/regular/opensans-italic-webfont.eot?#iefix') format('embedded-opentype'),
-         url('../fonts/open-sans/regular/opensans-italic-webfont.woff2') format('woff2'),
-         url('../fonts/open-sans/regular/opensans-italic-webfont.woff') format('woff'),
-         url('../fonts/open-sans/regular/opensans-italic-webfont.ttf') format('truetype');
+    src: url('../fonts/open-sans/italic/opensans-italic-webfont.eot?#iefix') format('embedded-opentype'),
+         url('../fonts/open-sans/italic/opensans-italic-webfont.woff2') format('woff2'),
+         url('../fonts/open-sans/italic/opensans-italic-webfont.woff') format('woff'),
+         url('../fonts/open-sans/italic/opensans-italic-webfont.ttf') format('truetype');
     font-weight: normal;
     font-style: italic;
 }


### PR DESCRIPTION
After the migration from SASS to SCSS the italic font broke and part-up icons could not be loaded anymore.