### PR TITLE
fix(CSS): Overwrite conflicting styles in bootstrap

### DIFF
--- a/app/client/stylesheets/reset.css
+++ b/app/client/stylesheets/reset.css
@@ -51,5 +51,17 @@ table {
     border-spacing: 0;
 }
 a:hover,a:focus {
+    color: rgba(255,255,255,1);
     text-decoration: none;
+}
+
+textarea:focus, input:focus {
+    border-color: none;
+    outline: none;
+    box-shadow: none !important;
+    -moz-box-shadow: none !important;
+    -webkit-box-shadow: none !important;
+    transition: none;
+    -moz-transition: none;
+    -webkit-transition: none;
 }


### PR DESCRIPTION
Autoform tags uses bootstrap which gives conflicts with our styling. Each update caused bootstrap to
be included again so I've overwritten this in the reset.css

Closes: #1068