### PR TITLE
fix(activity-board): Only set delay on iOS and add css for overlow

### DIFF
--- a/app/.meteor/versions
+++ b/app/.meteor/versions
@@ -215,7 +215,6 @@ templating-tools@1.1.2
 tmeasday:publish-counts@0.8.0
 tmeasday:test-reporter-helpers@0.2.1
 tracker@1.1.3
-twbs:bootstrap@3.3.6
 ui@1.0.13
 underscore@1.0.10
 url@1.1.0

--- a/app/client/stylesheets/components/boardview/_boardview-card.scss
+++ b/app/client/stylesheets/components/boardview/_boardview-card.scss
@@ -1,8 +1,13 @@
 .pu-boardview-card {
     white-space: normal;
     cursor: move;
+    -webkit-overflow-scrolling: auto;
     -webkit-touch-callout: none;
     -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 
     &--is-ghost {
         border: 2px dashed #ccc;

--- a/app/client/stylesheets/components/boardview/_boardview-lane.scss
+++ b/app/client/stylesheets/components/boardview/_boardview-lane.scss
@@ -6,6 +6,13 @@
     border-radius: 4px;
     position: relative;
     max-width: 100vw;
+    -webkit-overflow-scrolling: auto;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 
     &__header, &__footer {
         position: absolute;

--- a/app/packages/partup-client-boardview/BoardView.js
+++ b/app/packages/partup-client-boardview/BoardView.js
@@ -190,7 +190,7 @@ Template.BoardView.onCreated(function () {
                     pull: true,
                     put: true,
                 },
-                delay: (Partup.client.isMobile.iOS() ? 250 : 0),
+                delay: (Partup.client.isMobile.iOS() ? 250 : false),
                 animation: 50,
                 draggable: '.pu-js-sortable-card',
                 filter: '.pu-dropdownie',
@@ -281,8 +281,6 @@ Template.BoardView.onCreated(function () {
 Template.BoardView.onRendered(function () {
     var template = this;
     template.loaded.set(true);
-    template.$el = $('.pu-partuppagelayout__content-horizontal');
-    template.elEdges = template.$el[0].getBoundingClientRect();
 });
 
 Template.BoardView.onDestroyed(function () {

--- a/app/packages/partup-client-boardview/Sortable.js
+++ b/app/packages/partup-client-boardview/Sortable.js
@@ -431,7 +431,7 @@
 				_on(ownerDocument, 'pointercancel', _this._onDrop);
 				_on(ownerDocument, 'selectstart', _this);
 
-				if (options.delay && options.delay > 0) {
+				if (options.delay) {
 					// If the user moves the pointer or let go the click or touch
 					// before the delay has been reached:
 					// disable the delayed drag


### PR DESCRIPTION
Lanes and cards now use the desired scrolling behavior and default touch actions are now prevented.

Closes: #1148