### PR TITLE
fix(partup-layout): Improve element layout for mobile

### DIFF
--- a/app/client/stylesheets/components/_pu-partuppagelayout.scss
+++ b/app/client/stylesheets/components/_pu-partuppagelayout.scss
@@ -115,7 +115,7 @@ $partup-navigation-compact-height: em(60);
 
                 // The rest of these sub classes are ugly work-arounds of default styling.
                 .pu-dropdown-expand {
-                    width: calc(100% - #{em(150)});
+                    width: calc(100% - #{em(100)});
                     padding: em(10) 0 0 0;
                     display:inline-block;
                 }
@@ -173,7 +173,8 @@ $partup-navigation-compact-height: em(60);
     }
 
     &-sidebar {
-        width: $sidebar-width;
+        width: 95%;
+        max-width: $sidebar-width;
         height: calc(100vh - #{$partup-navigation-compact-height});
         position: absolute;
         left: em(0);
@@ -184,6 +185,7 @@ $partup-navigation-compact-height: em(60);
         @include transition(transform .3s);
 
         @include goingLarge(810) {
+            width: $sidebar-width;
             height: calc(100vh - #{em(120)}); // find solution for -> // calc(#{$page-header} - #{$partup-navigation-compact-height}));
             top: $partup-navigation-compact-height;
         }
@@ -202,14 +204,29 @@ $partup-navigation-compact-height: em(60);
         width: 100vw;
         position:relative;
         z-index:0;
-
+        background-color: #fff;
+        
         @include transition(all .3s);
 
         &-reduced {
+            filter: brightness(89%);
+            pointer-events: none;
+            
+            a:hover {
+                cursor: default;
+            }
+    
             @include goingLarge(810) {
                 width: calc(100vw - #{$sidebar-width});
                 margin-left: $sidebar-width;
+                filter: none;
+                pointer-events: auto;
+
                 @include transition(all .3s);
+
+                a:hover {
+                    cursor: pointer;
+                }
             }
         }
     }

--- a/app/client/stylesheets/components/_pu-partuppagelayout.scss
+++ b/app/client/stylesheets/components/_pu-partuppagelayout.scss
@@ -10,6 +10,17 @@ $partup-navigation-compact-height: em(60);
     &-navigation {
         position: relative;
 
+        &-behind {
+            @include goingSmall(810) {
+                filter: brightness(89%);
+                pointer-events: none;
+
+                a, button {
+                    cursor: default;
+                }
+            }
+        }
+
         .pu-navigation {
             margin: 0;
             padding: 0;

--- a/app/client/stylesheets/components/_pu-partuppagelayout.scss
+++ b/app/client/stylesheets/components/_pu-partuppagelayout.scss
@@ -118,17 +118,19 @@ $partup-navigation-compact-height: em(60);
             .pu-nav-right {
                 width: calc(100% - #{$nav-left-collapsed});
                 padding: 0em em(25);
-                // white-space: nowrap;
 
                 @include goingLarge(980) {
                     width: calc(100% - #{$sidebar-width});
                 }
 
-                // The rest of these sub classes are ugly work-arounds of default styling.
                 .pu-dropdown-expand {
                     width: calc(100% - #{em(100)});
                     padding: em(10) 0 0 0;
                     display:inline-block;
+
+                    @include goingLarge(600) {
+                        width: calc(100% - #{em(150)});
+                    }
                 }
                 .pu-button-nav.middle {
                     border: none;

--- a/app/packages/partup-client-dropdowns/partials/partup/navigation.js
+++ b/app/packages/partup-client-dropdowns/partials/partup/navigation.js
@@ -28,14 +28,14 @@ Template.PartupNavigationSelector.onCreated(function() {
         icon: 'globe'
     }];
 
-    if (partup.isEditableBy(Meteor.user())) {
-        template.options.push({
-            name: TAPi18n.__('pages-app-partup-menu_settings'),
-            route: 'partup-settings',
-            slug: partupSlug,
-            icon: 'cog'
-        });
-    }
+    // if (partup.isEditableBy(Meteor.user())) {
+    //     template.options.push({
+    //         name: TAPi18n.__('pages-app-partup-menu_settings'),
+    //         route: 'partup-settings',
+    //         slug: partupSlug,
+    //         icon: 'cog'
+    //     });
+    // }
 
     var defaultOption = template.options[0];
 

--- a/app/packages/partup-client-dropdowns/partials/partup/navigation.js
+++ b/app/packages/partup-client-dropdowns/partials/partup/navigation.js
@@ -28,14 +28,14 @@ Template.PartupNavigationSelector.onCreated(function() {
         icon: 'globe'
     }];
 
-    // if (partup.isEditableBy(Meteor.user())) {
-    //     template.options.push({
-    //         name: TAPi18n.__('pages-app-partup-menu_settings'),
-    //         route: 'partup-settings',
-    //         slug: partupSlug,
-    //         icon: 'cog'
-    //     });
-    // }
+    if (partup.isEditableBy(Meteor.user())) {
+        template.options.push({
+            name: TAPi18n.__('pages-app-partup-menu_settings'),
+            route: 'partup-settings',
+            slug: partupSlug,
+            icon: 'cog'
+        });
+    }
 
     var defaultOption = template.options[0];
 

--- a/app/packages/partup-client-pages/app/partup/partup-navigation.html
+++ b/app/packages/partup-client-pages/app/partup/partup-navigation.html
@@ -87,13 +87,15 @@
                 </div>
             {{/if }}
             <ul class="pu-list pu-list-horizontal pu-list-horizontal-right no-margin">
-                {{#if partup.isEditableBy currentUser}}
-                    <li>
-                        <button class="pu-button pu-button-nav middle" data-toggle-partup-settings-dropdown>
-                            <i class="picon-cog"></i>
-                        </button> 
-                        {{> Dropdown toggle=settingsToggled template='partup_cog' data=. classes='pu-dropdownie-cog'}}
-                    </li>
+                {{#if screenWidthEqualOrAbove '810' }}
+                    {{#if partup.isEditableBy currentUser}}
+                        <li>
+                            <button class="pu-button pu-button-nav middle" data-toggle-partup-settings-dropdown>
+                                <i class="picon-cog"></i>
+                            </button> 
+                            {{> Dropdown toggle=settingsToggled template='partup_cog' data=. classes='pu-dropdownie-cog'}}
+                        </li>
+                    {{/if }}
                 {{/if }}
                 <li>
                     <button class="pu-button pu-button-nav middle" data-toggle-partup-share-dropdown>

--- a/app/packages/partup-client-pages/app/partup/partup-navigation.html
+++ b/app/packages/partup-client-pages/app/partup/partup-navigation.html
@@ -87,20 +87,20 @@
                 </div>
             {{/if }}
             <ul class="pu-list pu-list-horizontal pu-list-horizontal-right no-margin">
-                {{#if screenWidthEqualOrAbove '810' }}
-                    {{#if partup.isEditableBy currentUser}}
-                        <li>
-                            <button class="pu-button pu-button-nav middle" data-toggle-partup-settings-dropdown>
-                                <i class="picon-cog"></i>
-                            </button> 
-                            {{> Dropdown toggle=settingsToggled template='partup_cog' data=. classes='pu-dropdownie-cog'}}
-                        </li>
-                    {{/if }}
+                {{#if partup.isEditableBy currentUser}}
+                    <li>
+                        <button class="pu-button pu-button-nav middle" data-toggle-partup-settings-dropdown>
+                            <i class="picon-cog"></i>
+                        </button> 
+                        {{> Dropdown toggle=settingsToggled template='partup_cog' data=. classes='pu-dropdownie-cog'}}
+                    </li>
                 {{/if }}
                 <li>
                     <button class="pu-button pu-button-nav middle" data-toggle-partup-share-dropdown>
                         <i class="picon-share"></i>
-                        {{_ 'pages-app-partup-menu_share-button'}}
+                        {{#if screenWidthEqualOrAbove '600'}}
+                            {{_ 'pages-app-partup-menu_share-button'}}
+                        {{/if}}
                     </button> 
                     {{> Dropdown toggle=shareToggled template='partup_share' data=. classes='pu-dropdownie-share arrow-right'}}
                 </li>

--- a/app/packages/partup-client-pages/app/partup/partup.js
+++ b/app/packages/partup-client-pages/app/partup/partup.js
@@ -29,6 +29,7 @@ Template.app_partup.onCreated(function () {
     }
 
     template.sidebarExpanded = new ReactiveVar(undefined, (oldVal, newVal) => {
+        setClass(newVal, $('.pu-partuplayout-navigation'), 'pu-partuplayout-navigation-behind');
         setClass(newVal, $('.pu-partuplayout-sidebar'), 'pu-partuplayout-sidebar-expanded');
         setClass(newVal, $('.pu-partuplayout-content'), 'pu-partuplayout-content-reduced');
         setClass(newVal, $('#sidebar-chevron'), 'chevron-rotated');


### PR DESCRIPTION
- Sidebar width: 95%, max $sidebar-width
- Add filter to content when sidebar expanded
- Include settings cog in dropdown

If we wan't the filter to include the navigation-header then I have to adjust some css.