### PR TITLE
fix(comments): fixed error handling of comment field limit

### DIFF
--- a/app/packages/partup-client-comments/Comments.js
+++ b/app/packages/partup-client-comments/Comments.js
@@ -276,7 +276,7 @@ Template.Comments.events({
         event.preventDefault();
         template.showSystemMessages.set(!template.showSystemMessages.get());
     },
-    'keyup [data=commentfield]': function(event, template) {
+    'keyup [data-commentfield]': function(event, template) {
         var totalCharacters = event.currentTarget.value.length;
         if (totalCharacters > 1000) {
             template.tooManyCharacters.set(true);


### PR DESCRIPTION
This PR fixes the error message on the create_comment field #946