### PR TITLE
fix(activity-update): don't remove lane_id on update

### DIFF
--- a/app/packages/partup-lib/transformers/activity.js
+++ b/app/packages/partup-lib/transformers/activity.js
@@ -14,15 +14,16 @@ Partup.transformers.activity = {
      */
     'fromForm': function(fields, upperId, partupId) {
         return {
-            name: fields.name,
-            description: fields.description,
-            end_date: fields.end_date,
+            // name: fields.name,
+            // description: fields.description,
+            // end_date: fields.end_date,
             created_at: new Date(),
             updated_at: new Date(),
             creator_id: upperId,
             partup_id: partupId,
             archived: false,
-            lane_id: fields.lane_id
+            // lane_id: fields.lane_id,
+            ...fields,
         };
     }
 };

--- a/app/packages/partup-server/methods/activities/activities_methods.js
+++ b/app/packages/partup-server/methods/activities/activities_methods.js
@@ -61,16 +61,17 @@ Meteor.methods({
         // if (activity.isRemoved()) throw new Meteor.Error(404, 'activity_could_not_be_found');
 
         var partup = Partups.findOneOrFail(activity.partup_id);
-        
+
         if (!upper || !partup.hasUpper(upper._id)) {
             throw new Meteor.Error(401, 'unauthorized');
         }
 
         try {
             var updatedActivity = Partup.transformers.activity.fromForm(fields, activity.creator_id, activity.partup_id);
+
             updatedActivity.updated_at = new Date();
 
-            Activities.update(activityId, {$set: updatedActivity});
+            Activities.update(activityId, {$set: {...activity, ...updatedActivity}});
 
             // Post system message
             Partup.server.services.system_messages.send(upper, activity.update_id, 'system_activities_updated');


### PR DESCRIPTION
This PR fixes the unwanted removal of lane tags off activities on save #881