### PR TITLE
feat(toastr): Change toastr position to above intercom button

### DIFF
--- a/app/client/stylesheets/defaults/_body.scss
+++ b/app/client/stylesheets/defaults/_body.scss
@@ -7,7 +7,7 @@ body {
 
     #pu-notifycontainer {
         position: fixed;
-        bottom: 30px;
+        bottom: 100px;
         right: 0;
         z-index: 101;
         pointer-events: all;


### PR DESCRIPTION
Will now display the toastr above the intercom button, this is testable by adding an invalid file via a message. This can either be a file larger than 5mb or a file with an extension that is not allowed. The latter can be done by changing the file options to all files in the file browse dialog.