### PR TITLE
fix(client): Add touch delay on android for the boardview

### DIFF
--- a/app/packages/partup-client-boardview/BoardView.js
+++ b/app/packages/partup-client-boardview/BoardView.js
@@ -132,6 +132,13 @@ Template.BoardView.onCreated(function () {
             template.dragging.set(false);
         }, 250);
     };
+
+    const touchDelay = Partup.client.isMobile.iOS() ?
+        250 :
+    Partup.client.isMobile.Android() ?
+        400 :
+    false; // <--- desktop.
+
     template.createBoard = function () {
         var boardElement = template.$('[data-sortable-board]')[0];
 
@@ -141,7 +148,7 @@ Template.BoardView.onCreated(function () {
                 pull: false,
                 put: false
             },
-            delay: Partup.client.isMobile.isTabletOrMobile() ? 400 : false,
+            delay: touchDelay,
             animation: 150,
             draggable: '.pu-js-sortable-lane',
             handle: '.pu-boardview-lane__header',
@@ -160,7 +167,7 @@ Template.BoardView.onCreated(function () {
     const isMobile = Partup.client.isMobile.isTabletOrMobile();
     const scrollOffsetMargin = isMobile ?
         35 :
-        120;
+    120;    
 
     // The sortable lib already throttles the handler for us.
     const horizontalScrollHandler = function (offX, offY, originalEvent, hoverTargetEl, touchEvt) {
@@ -191,7 +198,7 @@ Template.BoardView.onCreated(function () {
                     pull: true,
                     put: true,
                 },
-                delay: Partup.client.isMobile.isTabletOrMobile() ? 400 : false,
+                delay: touchDelay,
                 animation: 50,
                 draggable: '.pu-js-sortable-card',
                 filter: '.pu-dropdownie',

--- a/app/packages/partup-client-boardview/BoardView.js
+++ b/app/packages/partup-client-boardview/BoardView.js
@@ -141,6 +141,7 @@ Template.BoardView.onCreated(function () {
                 pull: false,
                 put: false
             },
+            delay: Partup.client.isMobile.isTabletOrMobile() ? 400 : false,
             animation: 150,
             draggable: '.pu-js-sortable-lane',
             handle: '.pu-boardview-lane__header',
@@ -190,7 +191,7 @@ Template.BoardView.onCreated(function () {
                     pull: true,
                     put: true,
                 },
-                delay: (Partup.client.isMobile.iOS() ? 250 : false),
+                delay: Partup.client.isMobile.isTabletOrMobile() ? 400 : false,
                 animation: 50,
                 draggable: '.pu-js-sortable-card',
                 filter: '.pu-dropdownie',

--- a/app/packages/partup-client-boardview/Sortable.js
+++ b/app/packages/partup-client-boardview/Sortable.js
@@ -442,20 +442,47 @@
 					_on(ownerDocument, 'touchmove', _this._disableDelayedDrag);
 					_on(ownerDocument, 'pointermove', _this._disableDelayedDrag);
 
-                    var dragStartFn = setTimeout(dragStartFn, options.delay);
-					_this._dragStartTimer = dragStartFn;
+                    _this._dragStartTimer = setTimeout(dragStartFn, options.delay);
 				} else {
 					dragStartFn();
 				}
 
-
 			}
 		},
 
-		_disableDelayedDrag: function () {
+        _previousPos: {
+            x: null,
+            y: null,
+            set(x, y) {
+                this.x = x;
+                this.y = y;
+            }
+        },
+
+		_disableDelayedDrag: function (event) {
 			var ownerDocument = this.el.ownerDocument;
 
-			clearTimeout(this._dragStartTimer);
+            // Partup.client.isMobile.Android() && 
+            if (event) {
+                const offset = 10;
+
+                if (this._previousPos.x === null || this._previousPos.y === null) {
+                    this._previousPos.set(event.x, event.y);
+                }
+
+                if (
+                    !(event.x >= (this._previousPos.x + offset) || event.x <= (this._previousPos.x - offset)) &&
+                    !(event.y >= (this._previousPos.y + offset) || event.y <= (this._previousPos.y - offset))
+                    ) {
+                    return;
+                }
+                
+                this._previousPos.set(event.x, event.y);
+
+            }
+
+            clearTimeout(this._dragStartTimer);
+
 			_off(ownerDocument, 'mouseup', this._disableDelayedDrag);
 			_off(ownerDocument, 'touchend', this._disableDelayedDrag);
 			_off(ownerDocument, 'touchcancel', this._disableDelayedDrag);
@@ -878,7 +905,8 @@
 
 			clearInterval(this._loopId);
 			clearInterval(autoScroll.pid);
-			clearTimeout(this._dragStartTimer);
+            clearTimeout(this._dragStartTimer);
+            this._previousPos.set(null, null);
 
 			// Unbind events
 			_off(document, 'mousemove', this._onTouchMove);

--- a/app/packages/partup-client-boardview/Sortable.js
+++ b/app/packages/partup-client-boardview/Sortable.js
@@ -462,8 +462,7 @@
 		_disableDelayedDrag: function (event) {
 			var ownerDocument = this.el.ownerDocument;
 
-            // Partup.client.isMobile.Android() && 
-            if (event) {
+            if (event && Partup.client.isMobile.Android()) {
                 const offset = 10;
 
                 if (this._previousPos.x === null || this._previousPos.y === null) {


### PR DESCRIPTION
This change affects every device.

- Touch delay is set to 400ms;
- Touch delay is only active on Tablet or Mobile devices;
- Touch delay now also works for lanes;

To test:

1. Scroll horizontally on the lane-header.
1. Scroll vertically inside a line when starting on a card.

In both cases you should be only able to move the item if you hold your finger still for the duration of the delay.

Time spent: 1h37m

Closes: #1201