### PR TITLE
Fix boardview scroll landscape

### DIFF
--- a/app/client/stylesheets/components/_pu-app.scss
+++ b/app/client/stylesheets/components/_pu-app.scss
@@ -13,27 +13,22 @@
         }
     }
 
-    @media screen and (min-width: $breakpoint-desktop) {
-        padding-top: $spacing-app-headerheight;
+    padding-top: $spacing-app-headerheight;
 
-        // .pu-page
-        //     min-height: 100%
+    .pu-header {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 15;
+        transform: translateZ(0);
+    }
 
-        .pu-header {
-            position: fixed;
-            top: 0;
-            left: 0;
-            right: 0;
-            z-index: 15;
-            transform: translateZ(0);
-        }
+    &-home {
+        padding-top: 0;
 
-        &-home {
-            padding-top: 0;
-
-            .pu-page {
-                margin-top: 0;
-            }
+        .pu-page {
+            margin-top: 0;
         }
     }
 }

--- a/app/client/stylesheets/components/_pu-partuppagelayout.scss
+++ b/app/client/stylesheets/components/_pu-partuppagelayout.scss
@@ -264,7 +264,6 @@ $partup-navigation-compact-height: em(60);
     }
 
     .content-horizontal {
-        overflow-x: scroll;
-        overflow-y: hidden;
+        overflow: scroll;
     }
 }

--- a/app/client/stylesheets/components/boardview/_boardview.scss
+++ b/app/client/stylesheets/components/boardview/_boardview.scss
@@ -9,6 +9,9 @@
         font-size: 16px;
         margin-right: 20px;
         height: 100%;
+        min-height: 375px;
+        max-height: 1000px;
+        margin-bottom:25px;
     }
 
     &__add-lane-button {

--- a/app/client/stylesheets/components/boardview/_boardview.scss
+++ b/app/client/stylesheets/components/boardview/_boardview.scss
@@ -16,7 +16,7 @@
 
     &__add-lane-button {
         width: 280px;
-        min-height: 200px;
+        min-height: 375px;
         border: 2px dashed #ccc;
         background-color: #f9f9f9;
         border-radius: 4px;


### PR DESCRIPTION
This PR fixes lanes collapsing on screens with little height. A minimum height of 375px is set to all lanes.

The main part-up header that is on all pages is now positioned fixed instead of relative. This fixed a bug that caused extra space below the boardview. This means that every page on the platform is touched by this PR. I haven't found any differences so far while testing on staging.

Closes: #1239