### PR TITLE
fix(discover): re-enabled upper hover cards on discover page

### DIFF
--- a/app/packages/partup-client-pages/app/discover/partials/tile/active.html
+++ b/app/packages/partup-client-pages/app/discover/partials/tile/active.html
@@ -14,7 +14,10 @@
                 <ul class="pu-sub-avatar-list">
                     {{# each partup.avatars }}
                         {{# if data.upper }}
-                             <li style="
+                             <li
+                                data-hovercontainer="HoverContainer_upper"
+                                data-hovercontainer-context="{{ _id }}"
+                                style="
                                 {{# with avatarPosition }}
                                     -webkit-transform: translateX({{x}}px) translateY({{y}}px);
                                     -moz-transform: translateX({{x}}px) translateY({{y}}px);


### PR DESCRIPTION
This PR re-enabled the hovercards on discover page