### PR TITLE
fix($partup): Sidebar now shows the right date when a partup was archived

### DIFF
--- a/app/packages/partup-client-pages/app/partup/partup-sidebar.html
+++ b/app/packages/partup-client-pages/app/partup/partup-sidebar.html
@@ -9,7 +9,7 @@
         <figure class="pu-sub-picture" style="{{#with partup.image }}background-image: url('{{ partupImageUrl id=. store='1200x520' }}');{{/with}}" data-partupcover-focuspoint></figure>
         {{#if partup.archived_at}}
             <div class="pu-state-message">
-                <h3>{{_ 'pages-app-partup-archive-info' }} <strong>{{ partupDateOnly archived_at }}</strong></h3>
+                <h3>{{_ 'pages-app-partup-archive-info' }} <strong>{{ partupDateOnly partup.archived_at }}</strong></h3>
             </div>
         {{/if}}
         <div class="pu-sub-title">


### PR DESCRIPTION
Instead of today's date, the sidebar now shows the correct date when a part-up was archived

This solves #1085.