### PR TITLE
fix(board): A removed activity now doesn't show up the lanes anymore

### DIFF
--- a/app/packages/partup-client-boardview/BoardView.js
+++ b/app/packages/partup-client-boardview/BoardView.js
@@ -245,7 +245,7 @@ Template.BoardView.onCreated(function () {
 
             lane.activities = (lane && lane.activities || []).map(function (activityId, activityIndex) {
                 return Activities.findOne(activityId);
-            }).filter(function (activity) { return !!(activity && !activity.isRemoved()); });
+            }).filter(function (activity) { return (activity && !activity.isRemoved()); });
 
             lane.activitiesCount = lane.activities.length;
 

--- a/app/packages/partup-client-boardview/BoardView.js
+++ b/app/packages/partup-client-boardview/BoardView.js
@@ -245,7 +245,7 @@ Template.BoardView.onCreated(function () {
 
             lane.activities = (lane && lane.activities || []).map(function (activityId, activityIndex) {
                 return Activities.findOne(activityId);
-            }).filter(function (activity) { return !!activity; });
+            }).filter(function (activity) { return !!(activity && !activity.isRemoved()); });
 
             lane.activitiesCount = lane.activities.length;
 


### PR DESCRIPTION
When an activity was removed, it was shown striketrough on the activity view in board-mode. This
commit fixes this error and hides this activity: #1305 