### PR TITLE
fix($meteor): Remove fastclick and file upload logging

### DIFF
--- a/app/.meteor/packages
+++ b/app/.meteor/packages
@@ -22,7 +22,6 @@ dsyko:meteor-node-csv
 ecmascript@0.8.1              # Enable ECMAScript2015+ syntax in app code
 ejson@1.0.13
 es5-shim@4.6.15                # ECMAScript 5 compatibility for older browsers.
-fastclick@1.0.13
 francocatena:status
 http@1.2.12
 iron:router

--- a/app/packages/partup-server/routes/files/files_routes.js
+++ b/app/packages/partup-server/routes/files/files_routes.js
@@ -76,14 +76,14 @@ Router.route('/files/upload', { where: 'server' }).post(function() {
                         })(element, bytes);
 
                         // For now, log info about matching to improve this for the future
-                        if (!match) {
-                            let log = {
-                                filename,
-                                mimetype,
-                                bytes
-                            }
-                            winston.info(`No match found for: ${JSON.stringify(log, null, 2)}`);
-                        }
+                        // if (!match) {
+                        //     let log = {
+                        //         filename,
+                        //         mimetype,
+                        //         bytes
+                        //     }
+                        //     winston.info(`No match found for: ${JSON.stringify(log, null, 2)}`);
+                        // }
                     }
                 }
             }


### PR DESCRIPTION
This fix removes the fast click library to fix the bugs with upload button on mobile devices. The package introduced an unnecessary delay which resulted in several bugs. 

Logging for uploaded files is also removed as @noelheesen  needed some data about the magic bytes. 