### PR TITLE
fix($meteor): Comment button on updates now applies focus to the form field

### DIFF
--- a/app/packages/partup-client-comments/Comments.html
+++ b/app/packages/partup-client-comments/Comments.html
@@ -107,7 +107,6 @@
                     {{# if isMotivation }}
                         {{> afFieldInput type='textarea' name='content' class='pu-textarea pu-sub-comment' data-commentfield="" data-submit="return" placeholder=placeholders.comment data-validate-keyup=""}}
                     {{ else }}
-                    <br>RPZZZZ: Hier het commentaar veld met autofocus erbij<br>
                         {{> afFieldInput type='textarea' name='content' class='pu-textarea pu-textarea-grow pu-sub-comment' data-commentfield="" data-submit="return" placeholder=placeholders.comment rows=state.messageRows autofocus=''}}
                     {{/ if }}
                     {{#if state.messageTooLong}}

--- a/app/packages/partup-client-comments/Comments.html
+++ b/app/packages/partup-client-comments/Comments.html
@@ -107,7 +107,8 @@
                     {{# if isMotivation }}
                         {{> afFieldInput type='textarea' name='content' class='pu-textarea pu-sub-comment' data-commentfield="" data-submit="return" placeholder=placeholders.comment data-validate-keyup=""}}
                     {{ else }}
-                        {{> afFieldInput type='textarea' name='content' class='pu-textarea pu-textarea-grow pu-sub-comment' data-commentfield="" data-submit="return" placeholder=placeholders.comment rows=state.messageRows }}
+                    <br>RPZZZZ: Hier het commentaar veld met autofocus erbij<br>
+                        {{> afFieldInput type='textarea' name='content' class='pu-textarea pu-textarea-grow pu-sub-comment' data-commentfield="" data-submit="return" placeholder=placeholders.comment rows=state.messageRows autofocus=''}}
                     {{/ if }}
                     {{#if state.messageTooLong}}
                         <span class="pu-sub-error">{{_ 'widgetcommentfield-comment-maxreached'}}</span>

--- a/app/packages/partup-client-comments/Comments.js
+++ b/app/packages/partup-client-comments/Comments.js
@@ -68,6 +68,7 @@ Template.Comments.onRendered(function() {
     var partupId = template.data.update.partup_id;
     template.mentionsInput = Partup.client.forms.MentionsInput(template.input, {partupId: partupId});
     Partup.client.elements.onClickOutside([template.list], template.resetEditCommentForm);
+
 });
 
 Template.afFieldInput.onRendered(function() {
@@ -260,7 +261,7 @@ Template.Comments.events({
             template.showCommentClicked.set(true);
 
             Meteor.defer(function() {
-                var commentForm = template.find('[id=commentForm-' + updateId + ']');
+                var commentForm = template.find('[id$=commentForm-' + updateId + ']');
                 var field = lodash.find(commentForm, {name: 'content'});
                 if (field) field.focus();
             });

--- a/app/packages/partup-client-update/Update.js
+++ b/app/packages/partup-client-update/Update.js
@@ -151,17 +151,19 @@ Template.Update.helpers({
 Template.Update.events({
     'click [data-expand-comment-field]': function(event, template) {
         event.preventDefault();
+   
         var updateId = this.updateId;
         var proceed = function() {
             template.commentInputFieldExpanded.set(true);
             template.showCommentClicked.set(true);
 
             Meteor.defer(function() {
-                var commentForm = template.find('[id=commentForm-' + updateId + ']');
+                var commentForm = template.find('[id$=commentForm-' + updateId + ']');
                 var field = lodash.find(commentForm, { name: 'content' });
                 if (field) field.focus();
             });
         };
+
         if (Meteor.user()) {
             proceed();
         } else {


### PR DESCRIPTION
The selector for selecting the right form was broken due to `_.uniqueId()` used as a prefix in the commentform ID. Changed the selector for focus to match only at the end of the string.