### PR TITLE
fix($browser): This fixes the new lane input on firefox

### DIFF
--- a/app/packages/partup-client-boardview/BoardView.js
+++ b/app/packages/partup-client-boardview/BoardView.js
@@ -317,6 +317,8 @@ Template.BoardView.events({
     'keyup [data-add-lane-input]': function (event, template) {
         if (event.keyCode === 13) {
             template.addLane.set(false);
+            // Not every browser blurs after pressing enter (FF on Mac for example)
+            $(":focus").blur(); // Thus we force a blur
         }
     },
     'blur [data-add-lane-input]': function (event, template) {


### PR DESCRIPTION
When pressing enter when trying to add a new lane, Firefox on Mac does not blur and thus does not
trigger the adding of the lane, this fix forces a blur trough jQuery and triggers it anyway

closes #1312 and closes #1160