### PR TITLE
fix($meteor): Fixes the upper hover container for partup tiles

### DIFF
--- a/app/packages/partup-client-hover-container/HoverContainer.js
+++ b/app/packages/partup-client-hover-container/HoverContainer.js
@@ -35,7 +35,7 @@ Template.HoverContainer.onRendered(function() {
 
         // Gather data for tile
         var tileTemplate = $trigger.data('hovercontainer') || '';
-        var tileData = $trigger.attr('data-hovercontainer-context') || {};
+        var tileData = $trigger.data('hovercontainer-context') || {};
         var delay = parseInt($trigger.data('hovercontainer-delay')) || 500;
         var orientation = $trigger.data('hovercontainer-orientation') || 'top-bottom';
         var typeClass = $trigger.data('hovercontainer-class') || '';

--- a/app/packages/partup-client-pages/app/discover/partials/tile/active.html
+++ b/app/packages/partup-client-pages/app/discover/partials/tile/active.html
@@ -16,7 +16,7 @@
                         {{# if data.upper }}
                              <li
                                 data-hovercontainer="HoverContainer_upper"
-                                data-hovercontainer-context="{{ _id }}"
+                                data-hovercontainer-context="{{ data.upper._id }}"
                                 style="
                                 {{# with avatarPosition }}
                                     -webkit-transform: translateX({{x}}px) translateY({{y}}px);


### PR DESCRIPTION
The hover container expected an userId in data-hovercontainer-context, but used .attr to get the
attribute, but not the value, this commit fixes this by using .data() instead

This closes #1314 (and closes #1293 for me locally but validation would be nice)