### PR TITLE
fix(meteor): Add winston to package.json

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -23,7 +23,8 @@
     "meteor-node-stubs": "~0.2.11",
     "pluralize": "^4.0.0",
     "sanitize-html": "^1.14.1",
-    "sortablejs": "^1.5.0-rc1"
+    "sortablejs": "^1.5.0-rc1",
+    "winston": "^3.0.0-rc1"
   },
   "devDependencies": {
     "@meteorjs/eslint-config-meteor": "^1.0.5",


### PR DESCRIPTION
Added winston to the deps so it will always include even in prod. Can't test this locally, it works without this change even when I run `meteor run --production`.