### PR TITLE
fix(client): Properly extract file icon when multiple info objects found

### DIFF
--- a/app/packages/partup-lib/helpers/files/_filemap.js
+++ b/app/packages/partup-lib/helpers/files/_filemap.js
@@ -16,7 +16,7 @@ export default _filemap = [
                         bytes: '424D',
                         size: 2,
                         offset: 0,
-                    }
+                    },
                 ],
             },
             {
@@ -54,7 +54,7 @@ export default _filemap = [
                         size: 4,
                         offset: 0,
                     },
-                ]
+                ],
             },
             {
                 extension: 'jpeg',
@@ -80,7 +80,7 @@ export default _filemap = [
                         size: 4,
                         offset: 0,
                     },
-                ]
+                ],
             },
             {
                 extension: 'png',
@@ -90,7 +90,7 @@ export default _filemap = [
                         bytes: '89504E470D0A1A0A',
                         size: 8,
                         offset: 0,
-                    }
+                    },
                 ],
             },
             {
@@ -101,7 +101,7 @@ export default _filemap = [
                         bytes: '52494646', // + filesize + 57 45 42 50, don't know how to do this yet.
                         size: 4,
                         offset: 0,
-                    }
+                    },
                 ],
             },
             {
@@ -112,8 +112,8 @@ export default _filemap = [
                         bytes: '49492A00',
                         size: 4,
                         offset: 0,
-                    }
-                ]
+                    },
+                ],
             },
             {
                 extension: 'tiff',
@@ -123,8 +123,8 @@ export default _filemap = [
                         bytes: '49492A00',
                         size: 4,
                         offset: 0,
-                    }
-                ]
+                    },
+                ],
             },
         ],
     },
@@ -257,7 +257,7 @@ export default _filemap = [
                         bytes: 'ECA5C100',
                         size: 4,
                         offset: 512,
-                    }
+                    },
                 ],
             },
             {
@@ -278,8 +278,8 @@ export default _filemap = [
                         bytes: '504B0708',
                         size: 4,
                         offset: 0,
-                    }
-                ]
+                    },
+                ],
             },
             {
                 extension: 'dotx',
@@ -299,8 +299,8 @@ export default _filemap = [
                         bytes: '504B0708',
                         size: 4,
                         offset: 0,
-                    }
-                ]
+                    },
+                ],
             },
             {
                 extension: 'odt',
@@ -320,8 +320,8 @@ export default _filemap = [
                         bytes: '504B0708',
                         size: 4,
                         offset: 0,
-                    }
-                ]
+                    },
+                ],
             },
             {
                 extension: 'rtf',
@@ -331,8 +331,8 @@ export default _filemap = [
                         bytes: '7B5C72746631',
                         size: 6,
                         offset: 0,
-                    }
-                ]
+                    },
+                ],
             },
             {
                 extension: 'pdf',
@@ -342,9 +342,9 @@ export default _filemap = [
                     {
                         bytes: '25504446',
                         size: 4,
-                        offset: 0
-                    }
-                ]
+                        offset: 0,
+                    },
+                ],
             },
             {
                 extension: 'txt',
@@ -354,8 +354,8 @@ export default _filemap = [
                         bytes: '464F524Dnnnnnnnn46545854',
                         size: 12,
                         offset: 0,
-                    }
-                ]
+                    },
+                ],
             },
             {
                 extension: 'pages',
@@ -378,8 +378,8 @@ export default _filemap = [
                         bytes: 'D0CF11E0A1B11AE1',
                         size: 8,
                         offset: 0,
-                    }
-                ]
+                    },
+                ],
             },
             {
                 extension: 'pptx',
@@ -399,8 +399,8 @@ export default _filemap = [
                         bytes: '504B0708',
                         size: 4,
                         offset: 0,
-                    }
-                ]
+                    },
+                ],
             },
             {
                 extension: 'pps',
@@ -410,8 +410,8 @@ export default _filemap = [
                         bytes: 'D0CF11E0A1B11AE1',
                         size: 8,
                         offset: 0,
-                    }
-                ]
+                    },
+                ],
             },
             {
                 extension: 'ppsx',
@@ -435,8 +435,11 @@ export default _filemap = [
                         bytes: '504B0708',
                         size: 4,
                         offset: 0,
-                    }
-                ]
+                    },
+                ],
+            },
+            {
+                mime: 'application/vnd.google-apps.presentation',
             },
         ],
     },

--- a/app/packages/partup-lib/helpers/files/files.js
+++ b/app/packages/partup-lib/helpers/files/files.js
@@ -146,12 +146,8 @@ Partup.helpers.files = {
         }
 
         const info = this.getFileInfo(file);
-
-        if (info[0]) {
-            return info[0].icon;
-        }
         if (info) {
-            return info[0] ? info[0].icon : info.icon;
+            return (info[0] instanceof FileInfo) ? info[0].icon : info.icon;
         }
         return 'file.svg';
     },

--- a/app/packages/partup-lib/helpers/files/files.test.js
+++ b/app/packages/partup-lib/helpers/files/files.test.js
@@ -174,6 +174,10 @@ import './files';
         expect(Partup.helpers.files.getSvgIcon({ name: 'filename.doc', type: 'application/msword' })).to.equal('doc.svg');
     });
 
+    Tinytest.add("getSvgIcon returns icon when multiple FileInfo objects found", function () {
+        expect(Partup.helpers.files.getSvgIcon({ type: 'application/gzip' })).to.equal('zip.svg');
+    });
+
     // toUploadFilter
 
     Tinytest.add("toUploadFilter returns filter for category images", function(test) {


### PR DESCRIPTION
The info[0] object never returns false. I meant to check if info[0] was a FileInfo object itself. This happens when the lookup is done via mime `type` and multiple FileInfo objects found.