### PR TITLE
fix($schema): LinkedInUrl validator now accepts company urls

### DIFF
--- a/app/packages/partup-lib/services/validators.js
+++ b/app/packages/partup-lib/services/validators.js
@@ -37,7 +37,7 @@ Partup.services.validators = {
     // facebookUrl: /^http[s]?:\/\/(www\.)?facebook\.com\/\w+(\?.*)?$/,     //old
     facebookUrl: /^http[s]?:\/\/(www\.)?facebook\.com\/[a-zA-Z0-9._-]+\/?(\?.*)?$/, //new
     instagramUrl: /^http[s]?:\/\/(www\.)?instagram\.com\/[a-zA-Z0-9._-]+\/?(\?.*)?$/,
-    linkedinUrl: /^http[s]?:\/\/([a-zA-Z]+\.)?linkedin\.com\/(in\/[a-zA-Z0-9._-]+|pub\/.*|profile\/view)\/?(\?.*)?$/,
+    linkedinUrl: /^http[s]?:\/\/([a-zA-Z]+\.)?linkedin\.com\/(company\/.*|in\/[a-zA-Z0-9._-]+|pub\/.*|profile\/view)\/?(\?.*)?$/,
     twitterUrl: /^http[s]?:\/\/(www\.)?twitter\.com\/[a-zA-Z0-9._-]+\/?(\?.*)??$/,
 
     /**


### PR DESCRIPTION
Changing the regex for the LinkedInUrl validator to accept company urls. 

Side-effect: it's now possible to use company urls in your own profile as well.. If we don't want this we might want to implement 2 different validators, @ralphboeije?

This closes: #1378.