### PR TITLE
Fix Email Invite copy

### DIFF
--- a/app/packages/partup-server/constants.js
+++ b/app/packages/partup-server/constants.js
@@ -2,7 +2,7 @@
  @name Partup.constants
  @memberof Partup.factories
  */
-Partup.constants.EMAIL_FROM = process.env.PARTUP_EMAIL_FROM || 'Part-up <team@part-up.com>';
+Partup.constants.EMAIL_FROM = process.env.PARTUP_EMAIL_FROM || 'Part-up <notifications@part-up.com>';
 Partup.constants.CRON_DIGEST = process.env.PARTUP_CRON_DIGEST || 'at 09:00am every weekday';
 Partup.constants.CRON_ENDDATE_REMINDER = process.env.PARTUP_CRON_ENDDATE_REMINDER || 'every 1 hour on the 10th minute';
 Partup.constants.CRON_PROGRESS = process.env.PARTUP_CRON_PROGRESS || 'every 1 hour on the 15th minute';

--- a/app/packages/partup-server/event_handlers/invites/activities_invites_handler.js
+++ b/app/packages/partup-server/event_handlers/invites/activities_invites_handler.js
@@ -105,10 +105,13 @@ Event.on('invites.inserted.activity.by_email', function(inviter, partup, activit
         });
     };
 
+    // set email fromAddress
+    var fromAddress = Partup.constants.EMAIL_FROM.replace(/Part-up/, inviter.profile.name);
+
     // Set the email details
     var emailOptions = {
         type: 'invite_email_address_to_partup_activity',
-        fromAddress: Partup.constants.EMAIL_FROM.replace(/Part-up/, inviter.profile.name),
+        fromAddress: fromAddress + ' ' + TAPi18n.__('emails-invite_upper_to_partup_activity-via'),
         toAddress: email,
         subject: TAPi18n.__('emails-invite_upper_to_partup_activity-subject', {inviter: inviter.profile.name, activity: activity.name, partup: partup.name}, User(inviter).getLocale()),
         locale: User(inviter).getLocale(),

--- a/app/packages/partup-server/event_handlers/invites/networks_invites_handler.js
+++ b/app/packages/partup-server/event_handlers/invites/networks_invites_handler.js
@@ -78,7 +78,7 @@ Event.on('invites.inserted.network.by_email', function(inviter, network, email, 
     // Set the email details
     var emailOptions = {
         type: 'invite_email_address_to_network',
-        fromAddress: fromAddress + ' ' + TAPi18n.__('emails-invite_upper_to_partup_network-via'),
+        fromAddress: fromAddress + ' ' + TAPi18n.__('emails-invite_upper_to_network-via'),
         toAddress: email,
         subject: TAPi18n.__('emails-invite_upper_to_network-subject', {inviter: inviter.profile.name, network: network.name}, User(inviter).getLocale()),
         locale: User(inviter).getLocale(),

--- a/app/packages/partup-server/event_handlers/invites/networks_invites_handler.js
+++ b/app/packages/partup-server/event_handlers/invites/networks_invites_handler.js
@@ -78,7 +78,7 @@ Event.on('invites.inserted.network.by_email', function(inviter, network, email, 
     // Set the email details
     var emailOptions = {
         type: 'invite_email_address_to_network',
-        fromAddress: fromAddress + ' ' + TAPi18n.__('emails-invite_upper_to_partup_activity-via'),
+        fromAddress: fromAddress + ' ' + TAPi18n.__('emails-invite_upper_to_partup_network-via'),
         toAddress: email,
         subject: TAPi18n.__('emails-invite_upper_to_network-subject', {inviter: inviter.profile.name, network: network.name}, User(inviter).getLocale()),
         locale: User(inviter).getLocale(),

--- a/app/packages/partup-server/event_handlers/invites/networks_invites_handler.js
+++ b/app/packages/partup-server/event_handlers/invites/networks_invites_handler.js
@@ -73,10 +73,12 @@ Event.on('invites.inserted.network.by_email', function(inviter, network, email, 
         });
     };
 
+    fromAddress: Partup.constants.EMAIL_FROM.replace(/Part-up/, inviter.profile.name),
+
     // Set the email details
     var emailOptions = {
         type: 'invite_email_address_to_network',
-        fromAddress: Partup.constants.EMAIL_FROM.replace(/Part-up/, inviter.profile.name),
+        fromAddress: fromAddress + ' ' + TAPi18n.__('emails-invite_upper_to_partup_activity-via'),
         toAddress: email,
         subject: TAPi18n.__('emails-invite_upper_to_network-subject', {inviter: inviter.profile.name, network: network.name}, User(inviter).getLocale()),
         locale: User(inviter).getLocale(),

--- a/app/packages/partup-server/event_handlers/invites/networks_invites_handler.js
+++ b/app/packages/partup-server/event_handlers/invites/networks_invites_handler.js
@@ -73,7 +73,7 @@ Event.on('invites.inserted.network.by_email', function(inviter, network, email, 
         });
     };
 
-    fromAddress: Partup.constants.EMAIL_FROM.replace(/Part-up/, inviter.profile.name),
+    var fromAddress = Partup.constants.EMAIL_FROM.replace(/Part-up/, inviter.profile.name)
 
     // Set the email details
     var emailOptions = {

--- a/app/packages/partup-server/event_handlers/partups/partups_invited_handler.js
+++ b/app/packages/partup-server/event_handlers/partups/partups_invited_handler.js
@@ -100,7 +100,7 @@ Event.on('invites.inserted.partup.by_email', function(inviter, partup, email, na
     // Set the email details
     var emailOptions = {
         type: 'invite_email_address_to_partup',
-        fromAddress: fromAddress: fromAddress + ' ' + TAPi18n.__('emails-invite_upper_to_partup-via'),
+        fromAddress: fromAddress + ' ' + TAPi18n.__('emails-invite_upper_to_partup-via'),
         toAddress: email,
         subject: TAPi18n.__('emails-invite_upper_to_partup-subject', {inviter: inviter.profile.name, partup: partup.name}, User(inviter).getLocale()),
         locale: User(inviter).getLocale(),

--- a/app/packages/partup-server/event_handlers/partups/partups_invited_handler.js
+++ b/app/packages/partup-server/event_handlers/partups/partups_invited_handler.js
@@ -95,10 +95,12 @@ Event.on('invites.inserted.partup.by_email', function(inviter, partup, email, na
         });
     };
 
+    var fromAddress = Partup.constants.EMAIL_FROM.replace(/Part-up/, inviter.profile.name);
+
     // Set the email details
     var emailOptions = {
         type: 'invite_email_address_to_partup',
-        fromAddress: Partup.constants.EMAIL_FROM.replace(/Part-up/, inviter.profile.name),
+        fromAddress: fromAddress: fromAddress + ' ' + TAPi18n.__('emails-invite_upper_to_partup-via'),
         toAddress: email,
         subject: TAPi18n.__('emails-invite_upper_to_partup-subject', {inviter: inviter.profile.name, partup: partup.name}, User(inviter).getLocale()),
         locale: User(inviter).getLocale(),


### PR DESCRIPTION
This pull requests fixes the fromAddress header for all invites send from Part-up. It also now includes the notification@part-up.com email and a new text for `(no reply)` because of RFC822!