### PR TITLE
fix(build): Sanitize-HTML version locked to not include 'postcss'

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -13,18 +13,16 @@
     "node": "0.10.36"
   },
   "dependencies": {
-    "HTMLString": "^1.0.7",
     "babel-runtime": "^6.23.0",
     "bcrypt": "^1.0.2",
     "enum": "^2.4.0",
     "highlight.js": "^9.6.0",
+    "HTMLString": "^1.0.7",
     "lodash": "^4.17.4",
     "marked": "^0.3.6",
     "meteor-node-stubs": "~0.2.11",
     "pluralize": "^4.0.0",
-    "sanitize-html": "^1.14.1",
-    "sortablejs": "^1.5.0-rc1",
-    "winston": "^3.0.0-rc1"
+    "sanitize-html": "~1.14.1"
   },
   "devDependencies": {
     "@meteorjs/eslint-config-meteor": "^1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8539 +1,7197 @@
 {
-    "name": "part-up",
-    "version": "2.34.0",
-    "lockfileVersion": 1,
-    "requires": true,
-    "dependencies": {
-        "JSONStream": {
-            "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-            "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-            "dev": true,
-            "requires": {
-                "jsonparse": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz",
-                "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-            }
-        },
-        "abbrev": {
-            "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-            "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
-        },
-        "add-stream": {
-            "version": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-            "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
-            "dev": true
-        },
-        "adm-zip": {
-            "version": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
-            "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E=",
-            "dev": true
-        },
-        "agent-base": {
-            "version": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-            "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
-            "dev": true,
-            "requires": {
-                "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-                    "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-                    "dev": true
-                }
-            }
-        },
-        "ajv": {
-            "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-            "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-            "requires": {
-                "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
-            }
-        },
-        "align-text": {
-            "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-            "dev": true,
-            "requires": {
-                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
-                "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-            }
-        },
-        "amdefine": {
-            "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-            "dev": true
-        },
-        "ansi-cyan": {
-            "version": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
-            "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
-            "dev": true,
-            "requires": {
-                "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
-            }
-        },
-        "ansi-escapes": {
-            "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-            "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-            "dev": true
-        },
-        "ansi-red": {
-            "version": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
-            "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
-            "dev": true,
-            "requires": {
-                "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
-            }
-        },
-        "ansi-regex": {
-            "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-            "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-            "dev": true
-        },
-        "ansi-wrap": {
-            "version": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-            "dev": true
-        },
-        "any-shell-escape": {
-            "version": "https://registry.npmjs.org/any-shell-escape/-/any-shell-escape-0.1.1.tgz",
-            "integrity": "sha1-1Vq5ciRMcaml4asIefML8RCAaVk=",
-            "dev": true
-        },
-        "anymatch": {
-            "version": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-            "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-            "dev": true,
-            "requires": {
-                "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
-            }
-        },
-        "apn": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/apn/-/apn-2.1.5.tgz",
-            "integrity": "sha1-Xgtxk8ZGpV+hZYdBGNmvf3zP1ts=",
-            "requires": {
-                "debug": "2.6.9",
-                "http2": "https://github.com/node-apn/node-http2/archive/apn-2.1.4.tar.gz",
-                "jsonwebtoken": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.1.tgz",
-                "node-forge": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.49.tgz",
-                "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-            }
-        },
-        "aproba": {
-            "version": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-            "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s="
-        },
-        "archiver": {
-            "version": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
-            "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
-            "dev": true,
-            "requires": {
-                "archiver-utils": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
-                "async": "https://registry.npmjs.org/async/-/async-2.4.0.tgz",
-                "buffer-crc32": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-                "tar-stream": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
-                "walkdir": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
-                "zip-stream": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.1.1.tgz"
-            }
-        },
-        "archiver-utils": {
-            "version": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
-            "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
-            "dev": true,
-            "requires": {
-                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                "lazystream": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
-            }
-        },
-        "archy": {
-            "version": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-            "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-            "dev": true
-        },
-        "are-we-there-yet": {
-            "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-            "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-            "requires": {
-                "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
-            }
-        },
-        "arr-diff": {
-            "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-            "dev": true,
-            "requires": {
-                "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz"
-            }
-        },
-        "arr-flatten": {
-            "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-            "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
-            "dev": true
-        },
-        "arr-union": {
-            "version": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
-            "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
-            "dev": true
-        },
-        "array-differ": {
-            "version": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-            "dev": true
-        },
-        "array-find-index": {
-            "version": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-            "dev": true
-        },
-        "array-ify": {
-            "version": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-            "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
-            "dev": true
-        },
-        "array-parallel": {
-            "version": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
-            "integrity": "sha1-j3hTCJJu1apHjEfmTRszS2wMlH0="
-        },
-        "array-series": {
-            "version": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz",
-            "integrity": "sha1-3103v8XC7wdV4qpPkv6ufUtaly8="
-        },
-        "array-slice": {
-            "version": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-            "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
-            "dev": true
-        },
-        "array-uniq": {
-            "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-            "dev": true
-        },
-        "array-unique": {
-            "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-            "dev": true
-        },
-        "arrify": {
-            "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-            "dev": true
-        },
-        "asap": {
-            "version": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-            "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
-            "dev": true
-        },
-        "asn1": {
-            "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-        },
-        "assert-plus": {
-            "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-        },
-        "assertion-error": {
-            "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-            "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
-            "dev": true
-        },
-        "async": {
-            "version": "https://registry.npmjs.org/async/-/async-2.4.0.tgz",
-            "integrity": "sha1-SZAgDxjqW4N8LMT4wDGmmFw4VhE=",
-            "requires": {
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-            }
-        },
-        "async-each": {
-            "version": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
-            "integrity": "sha1-tn6Z7c3fllQeRK9WKQzX1cbnBDk=",
-            "dev": true
-        },
-        "asynckit": {
-            "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-        },
-        "atob": {
-            "version": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-            "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=",
-            "dev": true
-        },
-        "aws-sign2": {
-            "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-        },
-        "aws4": {
-            "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-        },
-        "babel-code-frame": {
-            "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-            "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-            "dev": true,
-            "requires": {
-                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-            }
-        },
-        "babel-core": {
-            "version": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
-            "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM=",
-            "dev": true,
-            "requires": {
-                "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
-                "babel-helpers": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-                "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-                "babel-register": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-                "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
-                "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-                "debug": "2.6.9",
-                "json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-                "slash": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-            }
-        },
-        "babel-generator": {
-            "version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
-            "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc=",
-            "dev": true,
-            "requires": {
-                "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-                "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-                "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                "trim-right": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
-            }
-        },
-        "babel-helper-bindify-decorators": {
-            "version": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
-            "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-helper-builder-binary-assignment-operator-visitor": {
-            "version": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-            "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-            "dev": true,
-            "requires": {
-                "babel-helper-explode-assignable-expression": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-helper-call-delegate": {
-            "version": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-            "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-            "dev": true,
-            "requires": {
-                "babel-helper-hoist-variables": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-helper-define-map": {
-            "version": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
-            "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-            }
-        },
-        "babel-helper-explode-assignable-expression": {
-            "version": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-            "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-helper-explode-class": {
-            "version": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
-            "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
-            "dev": true,
-            "requires": {
-                "babel-helper-bindify-decorators": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-helper-function-name": {
-            "version": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-            "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-            "dev": true,
-            "requires": {
-                "babel-helper-get-function-arity": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-helper-get-function-arity": {
-            "version": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-            "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-helper-hoist-variables": {
-            "version": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-            "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-helper-optimise-call-expression": {
-            "version": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-            "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-helper-regex": {
-            "version": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-            "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-            }
-        },
-        "babel-helper-remap-async-to-generator": {
-            "version": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-            "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-helper-replace-supers": {
-            "version": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-            "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-            "dev": true,
-            "requires": {
-                "babel-helper-optimise-call-expression": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-                "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-helpers": {
-            "version": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-            "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz"
-            }
-        },
-        "babel-messages": {
-            "version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-            "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-check-es2015-constants": {
-            "version": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-            "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-syntax-async-functions": {
-            "version": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-            "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-            "dev": true
-        },
-        "babel-plugin-syntax-async-generators": {
-            "version": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-            "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
-            "dev": true
-        },
-        "babel-plugin-syntax-class-properties": {
-            "version": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-            "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
-            "dev": true
-        },
-        "babel-plugin-syntax-decorators": {
-            "version": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-            "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
-            "dev": true
-        },
-        "babel-plugin-syntax-dynamic-import": {
-            "version": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-            "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
-            "dev": true
-        },
-        "babel-plugin-syntax-exponentiation-operator": {
-            "version": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-            "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-            "dev": true
-        },
-        "babel-plugin-syntax-object-rest-spread": {
-            "version": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-            "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-            "dev": true
-        },
-        "babel-plugin-syntax-trailing-function-commas": {
-            "version": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-            "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-            "dev": true
-        },
-        "babel-plugin-transform-async-generator-functions": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
-            "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
-            "dev": true,
-            "requires": {
-                "babel-helper-remap-async-to-generator": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-                "babel-plugin-syntax-async-generators": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-transform-async-to-generator": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-            "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-            "dev": true,
-            "requires": {
-                "babel-helper-remap-async-to-generator": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-                "babel-plugin-syntax-async-functions": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-transform-class-properties": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-            "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-                "babel-plugin-syntax-class-properties": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz"
-            }
-        },
-        "babel-plugin-transform-decorators": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
-            "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
-            "dev": true,
-            "requires": {
-                "babel-helper-explode-class": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
-                "babel-plugin-syntax-decorators": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-arrow-functions": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-            "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-block-scoped-functions": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-            "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-block-scoping": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-            "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-classes": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-            "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-            "dev": true,
-            "requires": {
-                "babel-helper-define-map": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
-                "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-                "babel-helper-optimise-call-expression": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-                "babel-helper-replace-supers": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-                "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-computed-properties": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-            "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-destructuring": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-            "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-duplicate-keys": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-            "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-for-of": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-            "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-function-name": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-            "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-literals": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-            "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-amd": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-            "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-commonjs": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-            "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-strict-mode": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-systemjs": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-            "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-            "dev": true,
-            "requires": {
-                "babel-helper-hoist-variables": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-umd": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-            "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-es2015-modules-amd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-object-super": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-            "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-            "dev": true,
-            "requires": {
-                "babel-helper-replace-supers": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-parameters": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-            "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-            "dev": true,
-            "requires": {
-                "babel-helper-call-delegate": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-                "babel-helper-get-function-arity": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-shorthand-properties": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-            "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-spread": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-            "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-sticky-regex": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-            "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-            "dev": true,
-            "requires": {
-                "babel-helper-regex": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-template-literals": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-            "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-typeof-symbol": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-            "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-transform-es2015-unicode-regex": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-            "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-            "dev": true,
-            "requires": {
-                "babel-helper-regex": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "regexpu-core": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
-            }
-        },
-        "babel-plugin-transform-exponentiation-operator": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-            "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-            "dev": true,
-            "requires": {
-                "babel-helper-builder-binary-assignment-operator-visitor": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-                "babel-plugin-syntax-exponentiation-operator": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-transform-object-rest-spread": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
-            "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-syntax-object-rest-spread": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-transform-regenerator": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
-            "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
-            "dev": true,
-            "requires": {
-                "regenerator-transform": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz"
-            }
-        },
-        "babel-plugin-transform-runtime": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
-            "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-            }
-        },
-        "babel-plugin-transform-strict-mode": {
-            "version": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-            "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
-            }
-        },
-        "babel-polyfill": {
-            "version": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-            "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-                "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-            }
-        },
-        "babel-preset-es2015": {
-            "version": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-            "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-check-es2015-constants": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-                "babel-plugin-transform-es2015-arrow-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-                "babel-plugin-transform-es2015-block-scoped-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-                "babel-plugin-transform-es2015-block-scoping": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-                "babel-plugin-transform-es2015-classes": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-                "babel-plugin-transform-es2015-computed-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-                "babel-plugin-transform-es2015-destructuring": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-                "babel-plugin-transform-es2015-duplicate-keys": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-                "babel-plugin-transform-es2015-for-of": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-                "babel-plugin-transform-es2015-function-name": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-                "babel-plugin-transform-es2015-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-                "babel-plugin-transform-es2015-modules-amd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-                "babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-                "babel-plugin-transform-es2015-modules-systemjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-                "babel-plugin-transform-es2015-modules-umd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-                "babel-plugin-transform-es2015-object-super": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-                "babel-plugin-transform-es2015-parameters": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-                "babel-plugin-transform-es2015-shorthand-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-                "babel-plugin-transform-es2015-spread": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-                "babel-plugin-transform-es2015-sticky-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-                "babel-plugin-transform-es2015-template-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-                "babel-plugin-transform-es2015-typeof-symbol": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-                "babel-plugin-transform-es2015-unicode-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-                "babel-plugin-transform-regenerator": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz"
-            }
-        },
-        "babel-preset-stage-2": {
-            "version": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
-            "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-syntax-dynamic-import": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-                "babel-plugin-transform-class-properties": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-                "babel-plugin-transform-decorators": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
-                "babel-preset-stage-3": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz"
-            }
-        },
-        "babel-preset-stage-3": {
-            "version": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
-            "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-syntax-trailing-function-commas": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-                "babel-plugin-transform-async-generator-functions": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
-                "babel-plugin-transform-async-to-generator": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-                "babel-plugin-transform-exponentiation-operator": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-                "babel-plugin-transform-object-rest-spread": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz"
-            }
-        },
-        "babel-register": {
-            "version": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-            "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
-            "dev": true,
-            "requires": {
-                "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-                "home-or-tmp": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "source-map-support": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz"
-            }
-        },
-        "babel-runtime": {
-            "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-            "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-            "dev": true,
-            "requires": {
-                "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-                "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-            }
-        },
-        "babel-template": {
-            "version": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-            "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-                "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-            }
-        },
-        "babel-traverse": {
-            "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-            "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU=",
-            "dev": true,
-            "requires": {
-                "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-                "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
-                "debug": "2.6.9",
-                "globals": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-                "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-            }
-        },
-        "babel-types": {
-            "version": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-            "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-            }
-        },
-        "babylon": {
-            "version": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
-            "integrity": "sha1-N9qUiHhIi5xOPEA4iT+jMUs/yTI=",
-            "dev": true
-        },
-        "balanced-match": {
-            "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-            "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-        },
-        "base64url": {
-            "version": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-            "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
-        },
-        "bcrypt": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-1.0.3.tgz",
-            "integrity": "sha512-pRyDdo73C8Nim3jwFJ7DWe3TZCgwDfWZ6nHS5LSdU77kWbj1frruvdndP02AOavtD4y8v6Fp2dolbHgp4SDrfg==",
-            "requires": {
-                "nan": "https://registry.npmjs.org/nan/-/nan-2.5.0.tgz",
-                "node-pre-gyp": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz"
-            }
-        },
-        "bcrypt-pbkdf": {
-            "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-            "optional": true,
-            "requires": {
-                "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-            }
-        },
-        "beeper": {
-            "version": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-            "dev": true
-        },
-        "binary-extensions": {
-            "version": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
-            "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
-            "dev": true
-        },
-        "bl": {
-            "version": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-            "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                },
-                "string_decoder": {
-                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                }
-            }
-        },
-        "block-stream": {
-            "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-            "requires": {
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            }
-        },
-        "bluebird": {
-            "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-            "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-            "dev": true
-        },
-        "boolbase": {
-            "version": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
-        },
-        "boom": {
-            "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-            "requires": {
-                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-            }
-        },
-        "brace-expansion": {
-            "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-            "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-            "requires": {
-                "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-            }
-        },
-        "braces": {
-            "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-            "dev": true,
-            "requires": {
-                "expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-                "preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-                "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-            }
-        },
-        "browser-stdout": {
-            "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-            "dev": true
-        },
-        "buffer-crc32": {
-            "version": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-            "dev": true
-        },
-        "buffer-equal-constant-time": {
-            "version": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
-        },
-        "buffer-shims": {
-            "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-            "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-        },
-        "builtin-modules": {
-            "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-            "dev": true
-        },
-        "bump-regex": {
-            "version": "https://registry.npmjs.org/bump-regex/-/bump-regex-2.7.0.tgz",
-            "integrity": "sha1-SiHiU3ETR2wCa+WIuKfd3vGTRkE=",
-            "dev": true,
-            "requires": {
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-        },
-        "busboy": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
-            "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
-            "requires": {
-                "dicer": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
-            }
-        },
-        "cachedir": {
-            "version": "https://registry.npmjs.org/cachedir/-/cachedir-1.1.1.tgz",
-            "integrity": "sha1-4TYwdeogahJ2fZK7cRyKL3ahD2I=",
-            "dev": true,
-            "requires": {
-                "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-            }
-        },
-        "camel-case": {
-            "version": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-            "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-            "dev": true,
-            "requires": {
-                "no-case": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
-                "upper-case": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
-            }
-        },
-        "camelcase": {
-            "version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-            "dev": true
-        },
-        "camelcase-keys": {
-            "version": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-            "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-            "dev": true,
-            "requires": {
-                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-            }
-        },
-        "caseless": {
-            "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-        },
-        "center-align": {
-            "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
-            }
-        },
-        "chai": {
-            "version": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-            "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-            "dev": true,
-            "requires": {
-                "assertion-error": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-                "deep-eql": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-                "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
-            }
-        },
-        "chai-as-promised": {
-            "version": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-6.0.0.tgz",
-            "integrity": "sha1-GgKkM6byTa+sY7nJb6FoTbGqjaY=",
-            "dev": true,
-            "requires": {
-                "check-error": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz"
-            }
-        },
-        "chalk": {
-            "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-            "dev": true,
-            "requires": {
-                "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-        },
-        "chdir-promise": {
-            "version": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.0.tgz",
-            "integrity": "sha1-RtxgLtGTGXRwFA8VJFmkOCz3mXQ=",
-            "dev": true,
-            "requires": {
-                "check-more-types": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-                "debug": "2.6.9",
-                "lazy-ass": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-                "q": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-                "spots": "https://registry.npmjs.org/spots/-/spots-0.4.0.tgz"
-            },
-            "dependencies": {
-                "q": {
-                    "version": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-                    "integrity": "sha1-Y1fikSBnAdmfGXq4TlforRlvKok=",
-                    "dev": true
-                }
-            }
-        },
-        "check-error": {
-            "version": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-            "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-            "dev": true
-        },
-        "check-more-types": {
-            "version": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-            "integrity": "sha1-YiYmTTCxCVqhwKW4dO291dLQpm8=",
-            "dev": true
-        },
-        "check-types": {
-            "version": "https://registry.npmjs.org/check-types/-/check-types-1.4.0.tgz",
-            "integrity": "sha1-7tY7usnqSaDiagljFAWLA7CN1is=",
-            "dev": true
-        },
-        "cheerio": {
-            "version": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
-            "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
-            "requires": {
-                "css-select": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
-                "dom-serializer": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-                "entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-                "htmlparser2": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-            },
-            "dependencies": {
-                "lodash": {
-                    "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-                }
-            }
-        },
-        "child-process-debug": {
-            "version": "https://registry.npmjs.org/child-process-debug/-/child-process-debug-0.0.7.tgz",
-            "integrity": "sha1-VOEfuBw7b5Spa2MfrKk+0a9/itA=",
-            "dev": true
-        },
-        "chimp": {
-            "version": "https://registry.npmjs.org/chimp/-/chimp-0.49.0.tgz",
-            "integrity": "sha1-8P5aBSSmMO+a9MvcOFIyfrgH4Pg=",
-            "dev": true,
-            "requires": {
-                "async": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
-                "babel-plugin-transform-runtime": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
-                "babel-polyfill": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-                "babel-preset-es2015": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-                "babel-preset-stage-2": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
-                "babel-register": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-                "chai": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-                "chai-as-promised": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-6.0.0.tgz",
-                "child-process-debug": "https://registry.npmjs.org/child-process-debug/-/child-process-debug-0.0.7.tgz",
-                "chokidar": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
-                "chromedriver": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.29.0.tgz",
-                "colors": "1.1.2",
-                "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                "cucumber": "git://github.com/xolvio/cucumber-js.git#cf953cb5b5de30dbcc279f59e4ebff3aa040071c",
-                "deep-extend": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                "exit": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-                "fibers": "https://registry.npmjs.org/fibers/-/fibers-1.0.15.tgz",
-                "freeport": "https://registry.npmjs.org/freeport/-/freeport-1.0.5.tgz",
-                "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-                "glob": "git://github.com/lucetius/node-glob.git#51c7ca6e69bfbd17db5f1ea710e3f2a7a457d9ce",
-                "hapi": "https://registry.npmjs.org/hapi/-/hapi-8.8.0.tgz",
-                "jasmine": "https://registry.npmjs.org/jasmine/-/jasmine-2.6.0.tgz",
-                "loglevel": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.1.tgz",
-                "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                "mocha": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-                "phantomjs-prebuilt": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.13.tgz",
-                "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-                "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-                "requestretry": "https://registry.npmjs.org/requestretry/-/requestretry-1.5.0.tgz",
-                "saucelabs": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.4.0.tgz",
-                "selenium-standalone": "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-5.11.2.tgz",
-                "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                "xolvio-ddp": "https://registry.npmjs.org/xolvio-ddp/-/xolvio-ddp-0.12.3.tgz",
-                "xolvio-jasmine-expect": "https://registry.npmjs.org/xolvio-jasmine-expect/-/xolvio-jasmine-expect-1.1.0.tgz",
-                "xolvio-sync-webdriverio": "https://registry.npmjs.org/xolvio-sync-webdriverio/-/xolvio-sync-webdriverio-9.0.1.tgz"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-                    "dev": true
-                },
-                "async-each": {
-                    "version": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-                    "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-                    "dev": true
-                },
-                "chokidar": {
-                    "version": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
-                    "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
-                    "dev": true,
-                    "requires": {
-                        "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-                        "async-each": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-                        "fsevents": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
-                        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "is-binary-path": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-                        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                        "readdirp": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
-                    }
-                },
-                "cucumber": {
-                    "version": "git://github.com/xolvio/cucumber-js.git#cf953cb5b5de30dbcc279f59e4ebff3aa040071c",
-                    "dev": true,
-                    "requires": {
-                        "camel-case": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-                        "cli-table": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-                        "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                        "colors": "1.1.2",
-                        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                        "duration": "https://registry.npmjs.org/duration/-/duration-0.2.0.tgz",
-                        "fibers": "https://registry.npmjs.org/fibers/-/fibers-1.0.15.tgz",
-                        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-                        "gherkin": "https://registry.npmjs.org/gherkin/-/gherkin-4.0.0.tgz",
-                        "glob": "git://github.com/lucetius/node-glob.git#51c7ca6e69bfbd17db5f1ea710e3f2a7a457d9ce",
-                        "is-generator": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
-                        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                        "meteor-promise": "https://registry.npmjs.org/meteor-promise/-/meteor-promise-0.8.4.tgz",
-                        "stack-chain": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-                        "stacktrace-js": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-1.3.1.tgz"
-                    }
-                },
-                "fsevents": {
-                    "version": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.1.tgz",
-                    "integrity": "sha1-8Z/Sj0Pur3YWgOUZogPE0LPTGv8=",
-                    "dependencies": {
-                        "abbrev": {
-                            "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-                            "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
-                        },
-                        "ansi-regex": {
-                            "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                        },
-                        "ansi-styles": {
-                            "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-                        },
-                        "aproba": {
-                            "version": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-                            "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s="
-                        },
-                        "are-we-there-yet": {
-                            "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-                            "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM="
-                        },
-                        "asn1": {
-                            "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-                        },
-                        "assert-plus": {
-                            "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-                        },
-                        "asynckit": {
-                            "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-                        },
-                        "aws-sign2": {
-                            "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-                        },
-                        "aws4": {
-                            "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-                            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-                        },
-                        "balanced-match": {
-                            "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                            "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-                        },
-                        "bcrypt-pbkdf": {
-                            "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40="
-                        },
-                        "block-stream": {
-                            "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-                            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
-                        },
-                        "boom": {
-                            "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
-                        },
-                        "brace-expansion": {
-                            "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                            "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk="
-                        },
-                        "buffer-shims": {
-                            "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                            "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-                        },
-                        "caseless": {
-                            "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                            "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
-                        },
-                        "chalk": {
-                            "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
-                        },
-                        "code-point-at": {
-                            "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-                        },
-                        "combined-stream": {
-                            "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
-                        },
-                        "commander": {
-                            "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q="
-                        },
-                        "concat-map": {
-                            "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                        },
-                        "console-control-strings": {
-                            "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-                        },
-                        "core-util-is": {
-                            "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-                        },
-                        "cryptiles": {
-                            "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
-                        },
-                        "dashdash": {
-                            "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-                            "dependencies": {
-                                "assert-plus": {
-                                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                                }
-                            }
-                        },
-                        "debug": {
-                            "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                            "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo="
-                        },
-                        "deep-extend": {
-                            "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                            "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM="
-                        },
-                        "delayed-stream": {
-                            "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-                        },
-                        "delegates": {
-                            "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-                        },
-                        "ecc-jsbn": {
-                            "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU="
-                        },
-                        "escape-string-regexp": {
-                            "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-                        },
-                        "extend": {
-                            "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                            "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
-                        },
-                        "extsprintf": {
-                            "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                            "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
-                        },
-                        "forever-agent": {
-                            "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-                        },
-                        "form-data": {
-                            "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-                            "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ="
-                        },
-                        "fs.realpath": {
-                            "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-                        },
-                        "fstream": {
-                            "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-                            "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI="
-                        },
-                        "fstream-ignore": {
-                            "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-                            "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU="
-                        },
-                        "gauge": {
-                            "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
-                            "integrity": "sha1-HCOFX5YvF7OtPQ3HRD8wRULt/gk="
-                        },
-                        "generate-function": {
-                            "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-                        },
-                        "generate-object-property": {
-                            "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA="
-                        },
-                        "getpass": {
-                            "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                            "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
-                            "dependencies": {
-                                "assert-plus": {
-                                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                                }
-                            }
-                        },
-                        "glob": {
-                            "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                            "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg="
-                        },
-                        "graceful-fs": {
-                            "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-                        },
-                        "graceful-readlink": {
-                            "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-                        },
-                        "har-validator": {
-                            "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                            "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0="
-                        },
-                        "has-ansi": {
-                            "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
-                        },
-                        "has-unicode": {
-                            "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-                            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-                        },
-                        "hawk": {
-                            "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
-                        },
-                        "hoek": {
-                            "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-                        },
-                        "http-signature": {
-                            "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
-                        },
-                        "inflight": {
-                            "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
-                        },
-                        "inherits": {
-                            "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-                        },
-                        "ini": {
-                            "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                            "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
-                        },
-                        "is-fullwidth-code-point": {
-                            "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
-                        },
-                        "is-my-json-valid": {
-                            "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-                            "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs="
-                        },
-                        "is-property": {
-                            "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
-                        },
-                        "is-typedarray": {
-                            "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-                        },
-                        "isarray": {
-                            "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                        },
-                        "isstream": {
-                            "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-                        },
-                        "jodid25519": {
-                            "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                            "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc="
-                        },
-                        "jsbn": {
-                            "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-                            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-                        },
-                        "json-schema": {
-                            "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-                        },
-                        "json-stringify-safe": {
-                            "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-                        },
-                        "jsonpointer": {
-                            "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-                            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
-                        },
-                        "jsprim": {
-                            "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-                            "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI="
-                        },
-                        "mime-db": {
-                            "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
-                            "integrity": "sha1-6v/NDk/Gk1z4E02iRuLmw1MFrf8="
-                        },
-                        "mime-types": {
-                            "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
-                            "integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4="
-                        },
-                        "minimatch": {
-                            "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                            "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q="
-                        },
-                        "minimist": {
-                            "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-                        },
-                        "mkdirp": {
-                            "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
-                        },
-                        "ms": {
-                            "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                            "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-                        },
-                        "node-pre-gyp": {
-                            "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.33.tgz",
-                            "integrity": "sha1-ZArFUZj2qSWXLgwWxKwmoDTV7Mk="
-                        },
-                        "nopt": {
-                            "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k="
-                        },
-                        "npmlog": {
-                            "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
-                            "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518="
-                        },
-                        "number-is-nan": {
-                            "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-                        },
-                        "oauth-sign": {
-                            "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-                        },
-                        "object-assign": {
-                            "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-                        },
-                        "once": {
-                            "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
-                        },
-                        "path-is-absolute": {
-                            "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-                        },
-                        "pinkie": {
-                            "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-                        },
-                        "pinkie-promise": {
-                            "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
-                        },
-                        "process-nextick-args": {
-                            "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-                        },
-                        "punycode": {
-                            "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-                        },
-                        "qs": {
-                            "version": "https://registry.npmjs.org/qs/-/qs-6.3.1.tgz",
-                            "integrity": "sha1-kYwLO802Z5dyuvE1say0wWUe150="
-                        },
-                        "rc": {
-                            "version": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-                            "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
-                            "dependencies": {
-                                "minimist": {
-                                    "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                                }
-                            }
-                        },
-                        "readable-stream": {
-                            "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-                            "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4="
-                        },
-                        "request": {
-                            "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-                            "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4="
-                        },
-                        "rimraf": {
-                            "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-                            "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ="
-                        },
-                        "semver": {
-                            "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                            "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
-                        },
-                        "set-blocking": {
-                            "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-                        },
-                        "signal-exit": {
-                            "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-                        },
-                        "sntp": {
-                            "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
-                        },
-                        "sshpk": {
-                            "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
-                            "integrity": "sha1-1agEziJpVRVjjnmNviMnPeBwpfo=",
-                            "dependencies": {
-                                "assert-plus": {
-                                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                                }
-                            }
-                        },
-                        "string-width": {
-                            "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
-                        },
-                        "string_decoder": {
-                            "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                        },
-                        "stringstream": {
-                            "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-                        },
-                        "strip-ansi": {
-                            "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
-                        },
-                        "strip-json-comments": {
-                            "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-                        },
-                        "supports-color": {
-                            "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                        },
-                        "tar": {
-                            "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-                            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
-                        },
-                        "tar-pack": {
-                            "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
-                            "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
-                            "dependencies": {
-                                "once": {
-                                    "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                                    "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA="
-                                },
-                                "readable-stream": {
-                                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-                                    "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA="
-                                }
-                            }
-                        },
-                        "tough-cookie": {
-                            "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                            "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
-                        },
-                        "tunnel-agent": {
-                            "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
-                        },
-                        "tweetnacl": {
-                            "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-                            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-                        },
-                        "uid-number": {
-                            "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-                            "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
-                        },
-                        "util-deprecate": {
-                            "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-                        },
-                        "uuid": {
-                            "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-                            "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
-                        },
-                        "verror": {
-                            "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                            "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
-                        },
-                        "wide-align": {
-                            "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-                            "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0="
-                        },
-                        "wrappy": {
-                            "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-                        },
-                        "xtend": {
-                            "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-                        }
-                    }
-                },
-                "glob": {
-                    "version": "git://github.com/lucetius/node-glob.git#51c7ca6e69bfbd17db5f1ea710e3f2a7a457d9ce",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                        "once": "https://registry.npmjs.org/once/-/once-1.3.0.tgz",
-                        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-                    }
-                },
-                "glob-parent": {
-                    "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-                    }
-                },
-                "is-glob": {
-                    "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                    }
-                },
-                "minimist": {
-                    "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                },
-                "once": {
-                    "version": "https://registry.npmjs.org/once/-/once-1.3.0.tgz",
-                    "integrity": "sha1-FRr4a/wfCMS58H0GqyUP/L61ZYE=",
-                    "dev": true
-                },
-                "readdirp": {
-                    "version": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-                    "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-                        "set-immediate-shim": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
-                    }
-                },
-                "underscore": {
-                    "version": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                }
-            }
-        },
-        "chokidar": {
-            "version": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.6.tgz",
-            "integrity": "sha1-ChwLzh4kmTr8EFpbgeom3aAeI68=",
-            "dev": true,
-            "requires": {
-                "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-                "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                "async-each": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
-                "fsevents": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
-                "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.3.0.tgz",
-                "is-binary-path": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
-                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                "readdirp": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz"
-            }
-        },
-        "chromedriver": {
-            "version": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.29.0.tgz",
-            "integrity": "sha1-4/2LPAjc4lYrgO8bC4Rll2WdDMM=",
-            "dev": true,
-            "requires": {
-                "adm-zip": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
-                "kew": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
-            }
-        },
-        "cli-cursor": {
-            "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-            "dev": true,
-            "requires": {
-                "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz"
-            }
-        },
-        "cli-table": {
-            "version": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-            "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-            "dev": true,
-            "requires": {
-                "colors": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
-            },
-            "dependencies": {
-                "colors": {
-                    "version": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-                    "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-                    "dev": true
-                }
-            }
-        },
-        "cli-width": {
-            "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-            "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
-            "dev": true
-        },
-        "cliui": {
-            "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-            },
-            "dependencies": {
-                "wordwrap": {
-                    "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-                    "dev": true,
-                    "optional": true
-                }
-            }
-        },
-        "clone": {
-            "version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-            "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
-            "dev": true
-        },
-        "clone-buffer": {
-            "version": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-            "dev": true
-        },
-        "clone-stats": {
-            "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-            "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-            "dev": true
-        },
-        "cloneable-readable": {
-            "version": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
-            "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
-            "dev": true,
-            "requires": {
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-            }
-        },
-        "co": {
-            "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-        },
-        "code-point-at": {
-            "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
-        "colors": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-            "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
-        },
-        "combined-stream": {
-            "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-            "requires": {
-                "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-            }
-        },
-        "commander": {
-            "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-            "dev": true,
-            "requires": {
-                "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-            }
-        },
-        "commitizen": {
-            "version": "https://registry.npmjs.org/commitizen/-/commitizen-2.9.6.tgz",
-            "integrity": "sha1-wNAFNe8mTaf2Nzft/aQiiYP6IpE=",
-            "dev": true,
-            "requires": {
-                "cachedir": "https://registry.npmjs.org/cachedir/-/cachedir-1.1.1.tgz",
-                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                "cz-conventional-changelog": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-1.2.0.tgz",
-                "dedent": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",
-                "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-                "find-node-modules": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-1.0.4.tgz",
-                "find-root": "https://registry.npmjs.org/find-root/-/find-root-1.0.0.tgz",
-                "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                "shelljs": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
-                "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
-            },
-            "dependencies": {
-                "cli-cursor": {
-                    "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-                    "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-                    "dev": true,
-                    "requires": {
-                        "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
-                    }
-                },
-                "cz-conventional-changelog": {
-                    "version": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-1.2.0.tgz",
-                    "integrity": "sha1-K8oElkyJGbI/P9aonvXmAIsxs/g=",
-                    "dev": true,
-                    "requires": {
-                        "conventional-commit-types": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.1.0.tgz",
-                        "lodash.map": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-                        "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                        "pad-right": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
-                        "right-pad": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
-                        "word-wrap": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.2.tgz"
-                    }
-                },
-                "external-editor": {
-                    "version": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
-                    "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
-                    "dev": true,
-                    "requires": {
-                        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-                        "spawn-sync": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-                        "tmp": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz"
-                    }
-                },
-                "figures": {
-                    "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-                    "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-                    "dev": true,
-                    "requires": {
-                        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                    }
-                },
-                "fs-extra": {
-                    "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-                    "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                        "jsonfile": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-                        "klaw": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
-                    }
-                },
-                "inquirer": {
-                    "version": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
-                    "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-                        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                        "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-                        "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-                        "external-editor": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
-                        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-                        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                        "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-                        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                        "run-async": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-                        "rx": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-                        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                    }
-                },
-                "lodash": {
-                    "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                    "integrity": "sha1-NKMFW6vgTOQkZ7YH1wAHLH/2v0I=",
-                    "dev": true
-                },
-                "minimist": {
-                    "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                },
-                "mute-stream": {
-                    "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-                    "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
-                    "dev": true
-                },
-                "onetime": {
-                    "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-                    "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-                    "dev": true
-                },
-                "restore-cursor": {
-                    "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                    "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-                    "dev": true,
-                    "requires": {
-                        "exit-hook": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-                        "onetime": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
-                    }
-                },
-                "tmp": {
-                    "version": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-                    "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
-                    "dev": true,
-                    "requires": {
-                        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-                    }
-                }
-            }
-        },
-        "compare-func": {
-            "version": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-            "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
-            "dev": true,
-            "requires": {
-                "array-ify": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-                "dot-prop": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz"
-            }
-        },
-        "compress-commons": {
-            "version": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.0.tgz",
-            "integrity": "sha1-WFhwku8g03y1i68AARLJJ4/3O58=",
-            "dev": true,
-            "requires": {
-                "buffer-crc32": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-                "crc32-stream": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
-                "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
-            }
-        },
-        "concat-map": {
-            "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "concat-stream": {
-            "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-            "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-            "dev": true,
-            "requires": {
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-                "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-            }
-        },
-        "console-control-strings": {
-            "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-        },
-        "conventional-changelog": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.4.tgz",
-            "integrity": "sha1-EIvHUMKjF+IA4vm0E8qqH4x++js=",
-            "dev": true,
-            "requires": {
-                "conventional-changelog-angular": "1.3.4",
-                "conventional-changelog-atom": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.0.tgz",
-                "conventional-changelog-codemirror": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.1.0.tgz",
-                "conventional-changelog-core": "1.9.0",
-                "conventional-changelog-ember": "0.2.6",
-                "conventional-changelog-eslint": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.1.0.tgz",
-                "conventional-changelog-express": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.1.0.tgz",
-                "conventional-changelog-jquery": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
-                "conventional-changelog-jscs": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
-                "conventional-changelog-jshint": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.1.0.tgz"
-            },
-            "dependencies": {
-                "conventional-changelog-angular": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.3.4.tgz",
-                    "integrity": "sha1-fXzfvTWJSDEpBNAiKaYf1gdc9FU=",
-                    "dev": true,
-                    "requires": {
-                        "compare-func": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-                        "github-url-from-git": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
-                        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
-                    }
-                },
-                "conventional-changelog-core": {
-                    "version": "1.9.0",
-                    "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.9.0.tgz",
-                    "integrity": "sha1-3l37wJGEdlZQjUo4njXJobxJ5/Q=",
-                    "dev": true,
-                    "requires": {
-                        "conventional-changelog-writer": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-1.4.1.tgz",
-                        "conventional-commits-parser": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.3.0.tgz",
-                        "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-                        "get-pkg-repo": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.3.0.tgz",
-                        "git-raw-commits": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.2.0.tgz",
-                        "git-remote-origin-url": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-                        "git-semver-tags": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.0.tgz",
-                        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-                        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-                        "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-                    }
-                },
-                "conventional-changelog-ember": {
-                    "version": "0.2.6",
-                    "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.6.tgz",
-                    "integrity": "sha1-i3NVQZ9RJ0k8TFYkc6svx5LxwrY=",
-                    "dev": true,
-                    "requires": {
-                        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
-                    }
-                }
-            }
-        },
-        "conventional-changelog-atom": {
-            "version": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.0.tgz",
-            "integrity": "sha1-Z6R8ZqQrL4kJ7xWHyZia4d5zC5I=",
-            "dev": true,
-            "requires": {
-                "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
-            }
-        },
-        "conventional-changelog-cli": {
-            "version": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.1.tgz",
-            "integrity": "sha1-HNWp264l/7X/5nr+8eE26s7v0tU=",
-            "dev": true,
-            "requires": {
-                "add-stream": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-                "conventional-changelog": "1.1.4",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-                "tempfile": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz"
-            }
-        },
-        "conventional-changelog-codemirror": {
-            "version": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.1.0.tgz",
-            "integrity": "sha1-dXelkdv5tTjnoVCn7mL2WihyszQ=",
-            "dev": true,
-            "requires": {
-                "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
-            }
-        },
-        "conventional-changelog-eslint": {
-            "version": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.1.0.tgz",
-            "integrity": "sha1-pSQR6ZngUBzlALhWsKZD0DMJB+I=",
-            "dev": true,
-            "requires": {
-                "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
-            }
-        },
-        "conventional-changelog-express": {
-            "version": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.1.0.tgz",
-            "integrity": "sha1-VcbIQcgRliA2wDe9vZZKVK4xD84=",
-            "dev": true,
-            "requires": {
-                "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
-            }
-        },
-        "conventional-changelog-jquery": {
-            "version": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
-            "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
-            "dev": true,
-            "requires": {
-                "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
-            }
-        },
-        "conventional-changelog-jscs": {
-            "version": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
-            "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
-            "dev": true,
-            "requires": {
-                "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
-            }
-        },
-        "conventional-changelog-jshint": {
-            "version": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.1.0.tgz",
-            "integrity": "sha1-AMq46aMxdIer2UxNhGcTQpGNKgc=",
-            "dev": true,
-            "requires": {
-                "compare-func": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-                "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
-            }
-        },
-        "conventional-changelog-writer": {
-            "version": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-1.4.1.tgz",
-            "integrity": "sha1-P0y00APrtWmJ0w00WJO1KkNjnI4=",
-            "dev": true,
-            "requires": {
-                "compare-func": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-                "conventional-commits-filter": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz",
-                "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-                "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.8.tgz",
-                "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                "split": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
-                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-            }
-        },
-        "conventional-commit-message": {
-            "version": "https://registry.npmjs.org/conventional-commit-message/-/conventional-commit-message-1.1.0.tgz",
-            "integrity": "sha1-7OjGYaFo6YNpLh1aFIday1lRD2o=",
-            "dev": true,
-            "requires": {
-                "check-more-types": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.3.0.tgz",
-                "cz-conventional-changelog": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-1.1.5.tgz",
-                "lazy-ass": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.3.0.tgz",
-                "word-wrap": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.1.0.tgz"
-            },
-            "dependencies": {
-                "check-more-types": {
-                    "version": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.3.0.tgz",
-                    "integrity": "sha1-uDl8adySo+ZF8YkywEWwnHRBnsQ=",
-                    "dev": true
-                },
-                "cz-conventional-changelog": {
-                    "version": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-1.1.5.tgz",
-                    "integrity": "sha1-Ck0VUMTi+2o67Y9s2FjCF2DhGbg=",
-                    "dev": true,
-                    "requires": {
-                        "word-wrap": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.1.0.tgz"
-                    }
-                },
-                "lazy-ass": {
-                    "version": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.3.0.tgz",
-                    "integrity": "sha1-fQ0U7vPslwLG8wxg6oHxqNP5APs=",
-                    "dev": true
-                },
-                "word-wrap": {
-                    "version": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.1.0.tgz",
-                    "integrity": "sha1-NWFT1h0QYQ1gB4XF1wEojgrnZKY=",
-                    "dev": true
-                }
-            }
-        },
-        "conventional-commit-types": {
-            "version": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.1.0.tgz",
-            "integrity": "sha1-RdhgOGyaLmU37pHYobYb0EEbPQQ=",
-            "dev": true
-        },
-        "conventional-commits-filter": {
-            "version": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz",
-            "integrity": "sha1-b8KmWTcrw/IznPn//34bA0S5MDk=",
-            "dev": true,
-            "requires": {
-                "is-subset": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-                "modify-values": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz"
-            }
-        },
-        "conventional-commits-parser": {
-            "version": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.3.0.tgz",
-            "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
-            "dev": true,
-            "requires": {
-                "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-                "is-text-path": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-                "split2": "https://registry.npmjs.org/split2/-/split2-2.1.1.tgz",
-                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-                "trim-off-newlines": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz"
-            }
-        },
-        "conventional-github-releaser": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/conventional-github-releaser/-/conventional-github-releaser-1.1.11.tgz",
-            "integrity": "sha1-Ov5Fq+vYxbJgZxf86xZodPddKJM=",
-            "dev": true,
-            "requires": {
-                "conventional-changelog": "1.1.4",
-                "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-                "git-semver-tags": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.0.tgz",
-                "github": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
-                "lodash.merge": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-                "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                "semver-regex": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
-                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-            }
-        },
-        "conventional-recommended-bump": {
-            "version": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.0.0.tgz",
-            "integrity": "sha1-bTA6J4N66Ti3xoyN3u00VZtLB4k=",
-            "dev": true,
-            "requires": {
-                "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-                "conventional-commits-filter": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz",
-                "conventional-commits-parser": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.3.0.tgz",
-                "git-raw-commits": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.2.0.tgz",
-                "git-semver-tags": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.0.tgz",
-                "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            }
-        },
-        "convert-source-map": {
-            "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-            "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
-            "dev": true
-        },
-        "core-js": {
-            "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-            "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
-            "dev": true
-        },
-        "core-util-is": {
-            "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "country-language": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/country-language/-/country-language-0.1.7.tgz",
-            "integrity": "sha1-eHD0uhJduaYHHxlze9nvk0OuNds=",
-            "requires": {
-                "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-                "underscore.deep": "https://registry.npmjs.org/underscore.deep/-/underscore.deep-0.5.1.tgz"
-            }
-        },
-        "crc": {
-            "version": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
-            "integrity": "sha1-naHpgOO9RPxck79as9ozeNheRms=",
-            "dev": true
-        },
-        "crc32-stream": {
-            "version": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
-            "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
-            "dev": true,
-            "requires": {
-                "crc": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
-            }
-        },
-        "cross-spawn": {
-            "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-            "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-            "requires": {
-                "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-                "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
-            }
-        },
-        "cryptiles": {
-            "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-            "requires": {
-                "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-            }
-        },
-        "css": {
-            "version": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-            "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
-            "dev": true,
-            "requires": {
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                "source-map-resolve": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-                "urix": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                    "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-                    "dev": true,
-                    "requires": {
-                        "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-                    }
-                }
-            }
-        },
-        "css-parse": {
-            "version": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
-            "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
-            "dev": true,
-            "requires": {
-                "css": "https://registry.npmjs.org/css/-/css-2.2.1.tgz"
-            }
-        },
-        "css-select": {
-            "version": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
-            "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
-            "requires": {
-                "boolbase": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-                "css-what": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
-                "domutils": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-                "nth-check": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
-            }
-        },
-        "css-value": {
-            "version": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
-            "integrity": "sha1-Xv1sLupeof1rasV+wEJ7GEUkJOo=",
-            "dev": true
-        },
-        "css-what": {
-            "version": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
-            "integrity": "sha1-18wt9FGAZm+Z0rFEYmOUaeAPc2w="
-        },
-        "ctype": {
-            "version": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-            "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
-            "dev": true
-        },
-        "currently-unhandled": {
-            "version": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-            "dev": true,
-            "requires": {
-                "array-find-index": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
-            }
-        },
-        "cycle": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-            "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
-        },
-        "cz-conventional-changelog": {
-            "version": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-2.0.0.tgz",
-            "integrity": "sha1-Val5r9/pXnAkh50qD1kkYwFwtTM=",
-            "dev": true,
-            "requires": {
-                "conventional-commit-types": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.1.0.tgz",
-                "lodash.map": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-                "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                "pad-right": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
-                "right-pad": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
-                "word-wrap": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.2.tgz"
-            }
-        },
-        "d": {
-            "version": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-            "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
-            "dev": true,
-            "requires": {
-                "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-            }
-        },
-        "d3-helpers": {
-            "version": "https://registry.npmjs.org/d3-helpers/-/d3-helpers-0.3.0.tgz",
-            "integrity": "sha1-SzHc5KISGnczY4RXTYk/vtX7KT0=",
-            "dev": true
-        },
-        "dargs": {
-            "version": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
-            "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-            "dev": true,
-            "requires": {
-                "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-            }
-        },
-        "dashdash": {
-            "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "requires": {
-                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
-            }
-        },
-        "dateformat": {
-            "version": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-            "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-            "dev": true,
-            "requires": {
-                "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
-            }
-        },
-        "ddp-ejson": {
-            "version": "https://registry.npmjs.org/ddp-ejson/-/ddp-ejson-0.8.1-3.tgz",
-            "integrity": "sha1-6dZ0Zqt4m9dOfZcHSjbiQGkO7sI=",
-            "dev": true,
-            "requires": {
-                "ddp-underscore-patched": "https://registry.npmjs.org/ddp-underscore-patched/-/ddp-underscore-patched-0.8.1-2.tgz"
-            }
-        },
-        "ddp-underscore-patched": {
-            "version": "https://registry.npmjs.org/ddp-underscore-patched/-/ddp-underscore-patched-0.8.1-2.tgz",
-            "integrity": "sha1-ZaQU6fIuxagqoWOG40NmtI/Ozx0=",
-            "dev": true
-        },
-        "debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "requires": {
-                "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-            }
-        },
-        "decamelize": {
-            "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-            "dev": true
-        },
-        "dedent": {
-            "version": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",
-            "integrity": "sha1-Dm2o8M5Sg471zsXI+TlrDBtko8s=",
-            "dev": true
-        },
-        "deep-eql": {
-            "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-            "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-            "dev": true,
-            "requires": {
-                "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
-            },
-            "dependencies": {
-                "type-detect": {
-                    "version": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-                    "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-                    "dev": true
-                }
-            }
-        },
-        "deep-equal": {
-            "version": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-            "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
-            "dev": true
-        },
-        "deep-extend": {
-            "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-            "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM="
-        },
-        "deeper": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz",
-            "integrity": "sha1-vFZOX3MXT98gHgiwADDooU2nQ2g="
-        },
-        "deepmerge": {
-            "version": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.3.2.tgz",
-            "integrity": "sha1-FmNpFinU2/42T6EqKk8KqGqjoFA=",
-            "dev": true
-        },
-        "defaults": {
-            "version": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-            "dev": true,
-            "requires": {
-                "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-            }
-        },
-        "define-properties": {
-            "version": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-            "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-            "dev": true,
-            "requires": {
-                "foreach": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-                "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
-            }
-        },
-        "delayed-stream": {
-            "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-        },
-        "delegates": {
-            "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-        },
-        "deprecated": {
-            "version": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-            "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
-            "dev": true
-        },
-        "detect-file": {
-            "version": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
-            "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-            "dev": true,
-            "requires": {
-                "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
-            }
-        },
-        "detect-indent": {
-            "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-            "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-            "dev": true,
-            "requires": {
-                "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
-            }
-        },
-        "dicer": {
-            "version": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
-            "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
-            "requires": {
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                "streamsearch": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "requires": {
-                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                },
-                "string_decoder": {
-                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                }
-            }
-        },
-        "diff": {
-            "version": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-            "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
-            "dev": true
-        },
-        "dom-serializer": {
-            "version": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-            "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-            "requires": {
-                "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-                "entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
-            },
-            "dependencies": {
-                "domelementtype": {
-                    "version": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-                    "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
-                }
-            }
-        },
-        "domelementtype": {
-            "version": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-            "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
-        },
-        "domhandler": {
-            "version": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-            "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-            "requires": {
-                "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-            }
-        },
-        "domutils": {
-            "version": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-            "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
-            "requires": {
-                "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-            }
-        },
-        "dot-prop": {
-            "version": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-            "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-            "dev": true,
-            "requires": {
-                "is-obj": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
-            }
-        },
-        "duplexer2": {
-            "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-            "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                },
-                "string_decoder": {
-                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                }
-            }
-        },
-        "duration": {
-            "version": "https://registry.npmjs.org/duration/-/duration-0.2.0.tgz",
-            "integrity": "sha1-X5xN+q//ZV3phhEu/iXFl43YUUY=",
-            "dev": true,
-            "requires": {
-                "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-            }
-        },
-        "ecc-jsbn": {
-            "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-            "optional": true,
-            "requires": {
-                "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-            }
-        },
-        "ecdsa-sig-formatter": {
-            "version": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
-            "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
-            "requires": {
-                "base64url": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-                "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-            }
-        },
-        "ejs": {
-            "version": "https://registry.npmjs.org/ejs/-/ejs-2.5.6.tgz",
-            "integrity": "sha1-R5Y2v6P+Ox3r1SCH8KyyBLTxnIg=",
-            "dev": true
-        },
-        "end-of-stream": {
-            "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-            "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-            "dev": true,
-            "requires": {
-                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-            }
-        },
-        "entities": {
-            "version": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-            "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
-        },
-        "error-ex": {
-            "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-            "dev": true,
-            "requires": {
-                "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-            }
-        },
-        "error-stack-parser": {
-            "version": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
-            "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
-            "dev": true,
-            "requires": {
-                "stackframe": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz"
-            }
-        },
-        "es5-ext": {
-            "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-            "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY=",
-            "dev": true,
-            "requires": {
-                "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-                "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-            }
-        },
-        "es6-iterator": {
-            "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-            "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-            "dev": true,
-            "requires": {
-                "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-                "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-            },
-            "dependencies": {
-                "d": {
-                    "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                    "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-                    "dev": true,
-                    "requires": {
-                        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-                    }
-                }
-            }
-        },
-        "es6-promise": {
-            "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
-            "integrity": "sha1-eILzCt3lskDM+n99eMVIMwlRrkI=",
-            "dev": true
-        },
-        "es6-symbol": {
-            "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-            "dev": true,
-            "requires": {
-                "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-            },
-            "dependencies": {
-                "d": {
-                    "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                    "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-                    "dev": true,
-                    "requires": {
-                        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-                    }
-                }
-            }
-        },
-        "escape-string-regexp": {
-            "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
-        },
-        "esutils": {
-            "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-            "dev": true
-        },
-        "eventemitter2": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-4.1.2.tgz",
-            "integrity": "sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU="
-        },
-        "exit": {
-            "version": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-            "dev": true
-        },
-        "exit-hook": {
-            "version": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-            "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-            "dev": true
-        },
-        "expand-brackets": {
-            "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-            "dev": true,
-            "requires": {
-                "is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
-            }
-        },
-        "expand-range": {
-            "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "dev": true,
-            "requires": {
-                "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
-            }
-        },
-        "expand-tilde": {
-            "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-            "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-            "dev": true,
-            "requires": {
-                "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-            }
-        },
-        "extend": {
-            "version": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-        },
-        "extend-shallow": {
-            "version": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
-            "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
-            "dev": true,
-            "requires": {
-                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-                    "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
-                    "dev": true
-                }
-            }
-        },
-        "external-editor": {
-            "version": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
-            "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
-            "dev": true,
-            "requires": {
-                "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz",
-                "jschardet": "https://registry.npmjs.org/jschardet/-/jschardet-1.4.2.tgz",
-                "tmp": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz"
-            }
-        },
-        "extglob": {
-            "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-            "dev": true,
-            "requires": {
-                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-            }
-        },
-        "extract-zip": {
-            "version": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
-            "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
-            "dev": true,
-            "requires": {
-                "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-                "debug": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                "yauzl": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz"
-            },
-            "dependencies": {
-                "concat-stream": {
-                    "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-                    "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
-                    "dev": true,
-                    "requires": {
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                        "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                    }
-                },
-                "debug": {
-                    "version": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-                    "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-                    "dev": true
-                },
-                "mkdirp": {
-                    "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                    "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    }
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                },
-                "string_decoder": {
-                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                }
-            }
-        },
-        "extsprintf": {
-            "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-            "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
-        },
-        "eyes": {
-            "version": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-            "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
-        },
-        "fancy-log": {
-            "version": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-            "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
-            "dev": true,
-            "requires": {
-                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                "time-stamp": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz"
-            }
-        },
-        "faye-websocket": {
-            "version": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz",
-            "integrity": "sha1-iFk0x57/sECVSeDAo4Ae0XpAza0=",
-            "dev": true,
-            "requires": {
-                "websocket-driver": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz"
-            }
-        },
-        "fd-slicer": {
-            "version": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-            "dev": true,
-            "requires": {
-                "pend": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
-            }
-        },
-        "fg-lodash": {
-            "version": "https://registry.npmjs.org/fg-lodash/-/fg-lodash-0.0.2.tgz",
-            "integrity": "sha1-mINSU39CfaavIiEpu2OsyknmL6M=",
-            "dev": true,
-            "requires": {
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-                "underscore.string": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
-            },
-            "dependencies": {
-                "lodash": {
-                    "version": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-                    "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-                    "dev": true
-                }
-            }
-        },
-        "fibers": {
-            "version": "https://registry.npmjs.org/fibers/-/fibers-1.0.15.tgz",
-            "integrity": "sha1-IvA5yPGLhWGQ+75N7PBWFUwerpw=",
-            "dev": true
-        },
-        "figures": {
-            "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-            "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-            "dev": true,
-            "requires": {
-                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            }
-        },
-        "filename-regex": {
-            "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-            "dev": true
-        },
-        "fill-range": {
-            "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-            "dev": true,
-            "requires": {
-                "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                "randomatic": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-                "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-                "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-            }
-        },
-        "find-index": {
-            "version": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-            "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-            "dev": true
-        },
-        "find-node-modules": {
-            "version": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-1.0.4.tgz",
-            "integrity": "sha1-tt6zzMtpnIcDdne87eLF9YYrJVA=",
-            "dev": true,
-            "requires": {
-                "findup-sync": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz",
-                "merge": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
-            }
-        },
-        "find-root": {
-            "version": "https://registry.npmjs.org/find-root/-/find-root-1.0.0.tgz",
-            "integrity": "sha1-li/yEaqyXGUg/u641ih/j26VgHo=",
-            "dev": true
-        },
-        "find-up": {
-            "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-            "dev": true,
-            "requires": {
-                "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-            }
-        },
-        "findup": {
-            "version": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
-            "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
-            "dev": true,
-            "requires": {
-                "colors": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-                "commander": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
-            },
-            "dependencies": {
-                "colors": {
-                    "version": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-                    "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-                    "dev": true
-                },
-                "commander": {
-                    "version": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-                    "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
-                    "dev": true
-                }
-            }
-        },
-        "findup-sync": {
-            "version": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz",
-            "integrity": "sha1-qBF9D3MST1pFRoOVef5S1xKfteU=",
-            "dev": true,
-            "requires": {
-                "detect-file": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
-                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
-            },
-            "dependencies": {
-                "is-glob": {
-                    "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                    }
-                }
-            }
-        },
-        "fined": {
-            "version": "https://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
-            "integrity": "sha1-WyhCS3YNdZiWC374SA3/itNmDpc=",
-            "dev": true,
-            "requires": {
-                "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-                "lodash.assignwith": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
-                "lodash.isempty": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-                "lodash.isplainobject": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-                "lodash.isstring": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-                "lodash.pick": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-                "parse-filepath": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz"
-            }
-        },
-        "first-chunk-stream": {
-            "version": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
-        "flagged-respawn": {
-            "version": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
-            "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU=",
-            "dev": true
-        },
-        "for-in": {
-            "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-            "dev": true
-        },
-        "for-own": {
-            "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-            "dev": true,
-            "requires": {
-                "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
-            }
-        },
-        "foreach": {
-            "version": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-            "dev": true
-        },
-        "forever-agent": {
-            "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-        },
-        "form-data": {
-            "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-            "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-            "requires": {
-                "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
-            }
-        },
-        "freeport": {
-            "version": "https://registry.npmjs.org/freeport/-/freeport-1.0.5.tgz",
-            "integrity": "sha1-JV6KuEFwwzuoXZkOghrl9KGpvF0=",
-            "dev": true
-        },
-        "fs-exists-sync": {
-            "version": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-            "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
-            "dev": true
-        },
-        "fs-extra": {
-            "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-            "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                "jsonfile": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-                "klaw": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
-            }
-        },
-        "fs.realpath": {
-            "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-        },
-        "fsevents": {
-            "version": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
-            "integrity": "sha1-mZLxAyySXIKVVNDVmAHcoDE6U1Y=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "nan": "https://registry.npmjs.org/nan/-/nan-2.5.0.tgz"
-            }
-        },
-        "fstream": {
-            "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-            "requires": {
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
-            }
-        },
-        "fstream-ignore": {
-            "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-            "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-            "requires": {
-                "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
-            }
-        },
-        "function-bind": {
-            "version": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-            "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
-            "dev": true
-        },
-        "gauge": {
-            "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "requires": {
-                "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-                "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
-            }
-        },
-        "gaze": {
-            "version": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
-            "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
-            "dev": true,
-            "requires": {
-                "globule": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz"
-            }
-        },
-        "generate-function": {
-            "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-            "dev": true
-        },
-        "generate-object-property": {
-            "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-            "dev": true,
-            "requires": {
-                "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-            }
-        },
-        "get-pkg-repo": {
-            "version": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.3.0.tgz",
-            "integrity": "sha1-Q8a0wEi3XdYE/FOI7ezeVX9jNd8=",
-            "dev": true,
-            "requires": {
-                "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-                "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-                "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-                "parse-github-repo-url": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.0.tgz",
-                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-            }
-        },
-        "get-stdin": {
-            "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-            "dev": true
-        },
-        "getpass": {
-            "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "requires": {
-                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
-            }
-        },
-        "gherkin": {
-            "version": "https://registry.npmjs.org/gherkin/-/gherkin-4.0.0.tgz",
-            "integrity": "sha1-edzgTRIj6kO0hip2vlzo+JwSwyw=",
-            "dev": true
-        },
-        "git-raw-commits": {
-            "version": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.2.0.tgz",
-            "integrity": "sha1-DzqL/ZmuDy2LkiTViJKXXppS0Dw=",
-            "dev": true,
-            "requires": {
-                "dargs": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
-                "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-                "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-                "split2": "https://registry.npmjs.org/split2/-/split2-2.1.1.tgz",
-                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-            }
-        },
-        "git-remote-origin-url": {
-            "version": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-            "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
-            "dev": true,
-            "requires": {
-                "gitconfiglocal": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-                "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-            }
-        },
-        "git-semver-tags": {
-            "version": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.0.tgz",
-            "integrity": "sha1-sx/QLIq1eL1sm1ysyl4cZMEXesE=",
-            "dev": true,
-            "requires": {
-                "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-            }
-        },
-        "gitconfiglocal": {
-            "version": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-            "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
-            "dev": true,
-            "requires": {
-                "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-            }
-        },
-        "github": {
-            "version": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
-            "integrity": "sha1-JPp/DhP6EblGr5ETTFGYKpHOU4s=",
-            "dev": true,
-            "requires": {
-                "mime": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz"
-            }
-        },
-        "github-url-from-git": {
-            "version": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
-            "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
-            "dev": true
-        },
-        "glob": {
-            "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-            "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-            "requires": {
-                "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-            }
-        },
-        "glob-base": {
-            "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "dev": true,
-            "requires": {
-                "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-                    }
-                },
-                "is-glob": {
-                    "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                    }
-                }
-            }
-        },
-        "glob-parent": {
-            "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.3.0.tgz",
-            "integrity": "sha1-lx7dgW7V21hwW1gHlkemTQrveWg=",
-            "dev": true,
-            "requires": {
-                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-            },
-            "dependencies": {
-                "is-glob": {
-                    "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                    }
-                }
-            }
-        },
-        "glob-stream": {
-            "version": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-            "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
-            "dev": true,
-            "requires": {
-                "glob": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                "glob2base": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                "ordered-read-streams": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-                "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                "unique-stream": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                    "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-                    "dev": true,
-                    "requires": {
-                        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-                    }
-                },
-                "isarray": {
-                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
-                    }
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                },
-                "string_decoder": {
-                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                    }
-                }
-            }
-        },
-        "glob-watcher": {
-            "version": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-            "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
-            "dev": true,
-            "requires": {
-                "gaze": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
-            },
-            "dependencies": {
-                "gaze": {
-                    "version": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-                    "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-                    "dev": true,
-                    "requires": {
-                        "globule": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz"
-                    }
-                },
-                "glob": {
-                    "version": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                    "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
-                    }
-                },
-                "globule": {
-                    "version": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-                    "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-                    "dev": true,
-                    "requires": {
-                        "glob": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                        "lodash": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                    "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-                    "dev": true
-                },
-                "inherits": {
-                    "version": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                    "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-                    "dev": true
-                },
-                "lodash": {
-                    "version": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                    "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-                    "dev": true
-                },
-                "lru-cache": {
-                    "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                    "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                    "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                        "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                    }
-                }
-            }
-        },
-        "glob2base": {
-            "version": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-            "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-            "dev": true,
-            "requires": {
-                "find-index": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
-            }
-        },
-        "global-modules": {
-            "version": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-            "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-            "dev": true,
-            "requires": {
-                "global-prefix": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-                "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
-            }
-        },
-        "global-prefix": {
-            "version": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-            "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-            "dev": true,
-            "requires": {
-                "homedir-polyfill": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-                "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-                "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
-            }
-        },
-        "globals": {
-            "version": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-            "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=",
-            "dev": true
-        },
-        "globule": {
-            "version": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
-            "integrity": "sha1-xJNS5NwYPYWJPuglOF65lLtt9F8=",
-            "dev": true,
-            "requires": {
-                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
-                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
-            },
-            "dependencies": {
-                "lodash": {
-                    "version": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
-                    "integrity": "sha1-0iyaxmAojzhD4Wun0rXQbMon13c=",
-                    "dev": true
-                }
-            }
-        },
-        "glogg": {
-            "version": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-            "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-            "dev": true,
-            "requires": {
-                "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
-            }
-        },
-        "gm": {
-            "version": "1.23.0",
-            "resolved": "https://registry.npmjs.org/gm/-/gm-1.23.0.tgz",
-            "integrity": "sha1-gKL+nL8TFRUCSEZERlhGEmn1JmE=",
-            "requires": {
-                "array-parallel": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
-                "array-series": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz",
-                "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-                "debug": "2.2.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-                    "requires": {
-                        "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                    }
-                }
-            }
-        },
-        "graceful-fs": {
-            "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-        },
-        "graceful-readlink": {
-            "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-            "dev": true
-        },
-        "growl": {
-            "version": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-            "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
-            "dev": true
-        },
-        "growly": {
-            "version": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-            "dev": true
-        },
-        "gulp": {
-            "version": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-            "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
-            "dev": true,
-            "requires": {
-                "archy": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                "deprecated": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-                "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-                "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-                "liftoff": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
-                "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                "orchestrator": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-                "pretty-hrtime": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-                "semver": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                "tildify": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-                "v8flags": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-                "vinyl-fs": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                    "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-                    "dev": true
-                }
-            }
-        },
-        "gulp-bump": {
-            "version": "https://registry.npmjs.org/gulp-bump/-/gulp-bump-2.7.0.tgz",
-            "integrity": "sha1-TDdQvOk8XYFv6aFU5mGd1QmoUtg=",
-            "dev": true,
-            "requires": {
-                "bump-regex": "https://registry.npmjs.org/bump-regex/-/bump-regex-2.7.0.tgz",
-                "plugin-error": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
-                "plugin-log": "https://registry.npmjs.org/plugin-log/-/plugin-log-0.1.0.tgz",
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-            }
-        },
-        "gulp-conventional-changelog": {
-            "version": "https://registry.npmjs.org/gulp-conventional-changelog/-/gulp-conventional-changelog-1.1.3.tgz",
-            "integrity": "sha1-uIxpwpoq0t3fvt3p3ti5UKEW9EA=",
-            "dev": true,
-            "requires": {
-                "add-stream": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-                "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-                "conventional-changelog": "1.1.4",
-                "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-            }
-        },
-        "gulp-git": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/gulp-git/-/gulp-git-2.4.0.tgz",
-            "integrity": "sha1-luTO6/pTOFxfJmwVeB6CHwmeNYU=",
-            "dev": true,
-            "requires": {
-                "any-shell-escape": "https://registry.npmjs.org/any-shell-escape/-/any-shell-escape-0.1.1.tgz",
-                "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-                "require-dir": "0.3.2",
-                "strip-bom-stream": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-3.0.0.tgz",
-                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-                "vinyl": "2.0.2"
-            },
-            "dependencies": {
-                "clone-stats": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-                    "dev": true
-                },
-                "replace-ext": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
-                    "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-                        "clone-buffer": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
-                        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                        "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
-                        "replace-ext": "1.0.0"
-                    }
-                }
-            }
-        },
-        "gulp-help": {
-            "version": "https://registry.npmjs.org/gulp-help/-/gulp-help-1.6.1.tgz",
-            "integrity": "sha1-Jh2xhuGDl/7z9qLCLpwxW/qIrgw=",
-            "dev": true,
-            "requires": {
-                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-            },
-            "dependencies": {
-                "object-assign": {
-                    "version": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                    "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-                    "dev": true
-                }
-            }
-        },
-        "gulp-load-plugins": {
-            "version": "https://registry.npmjs.org/gulp-load-plugins/-/gulp-load-plugins-1.5.0.tgz",
-            "integrity": "sha1-TEGffldk2aDjMGG6uWGPgbc9QXE=",
-            "dev": true,
-            "requires": {
-                "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                "fancy-log": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-                "findup-sync": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz",
-                "gulplog": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-                "has-gulplog": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-                "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz"
-            }
-        },
-        "gulp-notify": {
-            "version": "https://registry.npmjs.org/gulp-notify/-/gulp-notify-3.0.0.tgz",
-            "integrity": "sha1-oEuK+azb5OY8hFZ4zgw9MGlMWaM=",
-            "dev": true,
-            "requires": {
-                "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-                "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-                "node-notifier": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
-                "node.extend": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
-                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-            }
-        },
-        "gulp-plumber": {
-            "version": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.1.0.tgz",
-            "integrity": "sha1-8SF2wtBCL2AwbCQv/2oBo5T6ugk=",
-            "dev": true,
-            "requires": {
-                "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-            }
-        },
-        "gulp-tag-version": {
-            "version": "https://registry.npmjs.org/gulp-tag-version/-/gulp-tag-version-1.3.0.tgz",
-            "integrity": "sha1-hEjIfu0YZtuObLWYvEGb4t98R9s=",
-            "dev": true,
-            "requires": {
-                "gulp-git": "https://registry.npmjs.org/gulp-git/-/gulp-git-0.3.6.tgz",
-                "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
-                "map-stream": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                    "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
-                    "dev": true
-                },
-                "ansi-styles": {
-                    "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-                    "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-                    "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-                        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-                        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-                        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-                    }
-                },
-                "gulp-git": {
-                    "version": "https://registry.npmjs.org/gulp-git/-/gulp-git-0.3.6.tgz",
-                    "integrity": "sha1-d+w9oiklwkbt15bKENQWOWXYFAo=",
-                    "dev": true,
-                    "requires": {
-                        "any-shell-escape": "https://registry.npmjs.org/any-shell-escape/-/any-shell-escape-0.1.1.tgz",
-                        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
-                        "map-stream": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-                        "through2": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz"
-                    }
-                },
-                "gulp-util": {
-                    "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
-                    "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-                        "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-                        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-                        "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-                        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
-                        "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-                        "through2": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-                        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz"
-                    },
-                    "dependencies": {
-                        "through2": {
-                            "version": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-                            "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-                            "dev": true,
-                            "requires": {
-                                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                                "xtend": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
-                            }
-                        }
-                    }
-                },
-                "has-ansi": {
-                    "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-                    "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                    }
-                },
-                "isarray": {
-                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "lodash._reinterpolate": {
-                    "version": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-                    "integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI=",
-                    "dev": true
-                },
-                "lodash.escape": {
-                    "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-                    "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._escapehtmlchar": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
-                        "lodash._reunescapedhtml": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
-                        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
-                    }
-                },
-                "lodash.keys": {
-                    "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                    "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-                        "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-                        "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
-                    }
-                },
-                "lodash.template": {
-                    "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-                    "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._escapestringchar": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
-                        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-                        "lodash.defaults": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
-                        "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-                        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                        "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
-                        "lodash.values": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
-                    }
-                },
-                "lodash.templatesettings": {
-                    "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
-                    "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-                        "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz"
-                    }
-                },
-                "map-stream": {
-                    "version": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-                    "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
-                    "dev": true
-                },
-                "minimist": {
-                    "version": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
-                    "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784=",
-                    "dev": true
-                },
-                "object-keys": {
-                    "version": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-                    "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                },
-                "string_decoder": {
-                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-                    "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                    }
-                },
-                "supports-color": {
-                    "version": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-                    "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-                    "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                        "xtend": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
-                    },
-                    "dependencies": {
-                        "xtend": {
-                            "version": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-                            "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-                            "dev": true,
-                            "requires": {
-                                "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
-                            }
-                        }
-                    }
-                },
-                "vinyl": {
-                    "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
-                    "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
-                    "dev": true,
-                    "requires": {
-                        "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-                    }
-                },
-                "xtend": {
-                    "version": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-                    "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
-                    "dev": true
-                }
-            }
-        },
-        "gulp-util": {
-            "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-            "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-            "dev": true,
-            "requires": {
-                "array-differ": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-                "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-                "beeper": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-                "fancy-log": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-                "gulplog": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-                "has-gulplog": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-                "lodash._reescape": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-                "lodash._reevaluate": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-                "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-                "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-                "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-                "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
-            },
-            "dependencies": {
-                "dateformat": {
-                    "version": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-                    "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc=",
-                    "dev": true
-                },
-                "lodash.template": {
-                    "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-                    "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                        "lodash._basetostring": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                        "lodash._basevalues": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-                        "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-                        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-                        "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-                        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                        "lodash.restparam": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-                        "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
-                    }
-                },
-                "lodash.templatesettings": {
-                    "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-                    "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-                        "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
-                    }
-                },
-                "minimist": {
-                    "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                },
-                "object-assign": {
-                    "version": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                    "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-                    "dev": true
-                }
-            }
-        },
-        "gulplog": {
-            "version": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-            "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-            "dev": true,
-            "requires": {
-                "glogg": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
-            }
-        },
-        "handlebars": {
-            "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.8.tgz",
-            "integrity": "sha1-Irh1zT8ObL6jAxTxROgrx6cv9CA=",
-            "dev": true,
-            "requires": {
-                "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-                    "dev": true,
-                    "requires": {
-                        "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-                    }
-                }
-            }
-        },
-        "hapi": {
-            "version": "https://registry.npmjs.org/hapi/-/hapi-8.8.0.tgz",
-            "integrity": "sha1-h+N6Bum0meiXkOLcERqpZotuYX8=",
-            "dev": true,
-            "requires": {
-                "accept": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz",
-                "ammo": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz",
-                "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                "call": "https://registry.npmjs.org/call/-/call-2.0.1.tgz",
-                "catbox": "https://registry.npmjs.org/catbox/-/catbox-4.3.0.tgz",
-                "catbox-memory": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz",
-                "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
-                "h2o2": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.1.tgz",
-                "heavy": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz",
-                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                "inert": "https://registry.npmjs.org/inert/-/inert-2.1.5.tgz",
-                "iron": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz",
-                "items": "https://registry.npmjs.org/items/-/items-1.1.0.tgz",
-                "joi": "https://registry.npmjs.org/joi/-/joi-6.4.1.tgz",
-                "kilt": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz",
-                "mimos": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
-                "peekaboo": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz",
-                "qs": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-                "shot": "https://registry.npmjs.org/shot/-/shot-1.5.3.tgz",
-                "statehood": "https://registry.npmjs.org/statehood/-/statehood-2.1.1.tgz",
-                "subtext": "https://registry.npmjs.org/subtext/-/subtext-1.1.1.tgz",
-                "topo": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz",
-                "vision": "https://registry.npmjs.org/vision/-/vision-2.0.1.tgz"
-            },
-            "dependencies": {
-                "accept": {
-                    "version": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz",
-                    "integrity": "sha1-g++IOWi4WkDFARYEKCoiD/AeYq0=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                    }
-                },
-                "ammo": {
-                    "version": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz",
-                    "integrity": "sha1-4FlIG/aAhzj66G1GT3L6DBLWeoU=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                    }
-                },
-                "boom": {
-                    "version": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                    "integrity": "sha1-2tYo2Jf3/S4yzIIZfxMweXHPg1Q=",
-                    "dev": true,
-                    "requires": {
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                    }
-                },
-                "call": {
-                    "version": "https://registry.npmjs.org/call/-/call-2.0.1.tgz",
-                    "integrity": "sha1-SbQnCZQ96JoyJYqpEbWHUeI3eg4=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                    }
-                },
-                "catbox": {
-                    "version": "https://registry.npmjs.org/catbox/-/catbox-4.3.0.tgz",
-                    "integrity": "sha1-IiN3vWfxKRrA4l0AAC0GWp3385o=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                        "joi": "https://registry.npmjs.org/joi/-/joi-6.4.1.tgz"
-                    }
-                },
-                "catbox-memory": {
-                    "version": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz",
-                    "integrity": "sha1-QqUvgLye+nJmAeltQBYDNhJIGig=",
-                    "dev": true,
-                    "requires": {
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                    }
-                },
-                "cryptiles": {
-                    "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
-                    "integrity": "sha1-CeoXdbnhx95+YKmdQqtvCM4aEoU=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz"
-                    }
-                },
-                "h2o2": {
-                    "version": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.1.tgz",
-                    "integrity": "sha1-eg4rztHZcXjsVs48ykjgxW3un40=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                        "joi": "https://registry.npmjs.org/joi/-/joi-6.4.1.tgz",
-                        "wreck": "5.6.1"
-                    },
-                    "dependencies": {
-                        "wreck": {
-                            "version": "5.6.1",
-                            "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.6.1.tgz",
-                            "integrity": "sha1-r/ADBAATiJ11YZtccYcN0qjdBpo=",
-                            "dev": true,
-                            "requires": {
-                                "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                            }
-                        }
-                    }
-                },
-                "heavy": {
-                    "version": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz",
-                    "integrity": "sha1-/QEIdiExYy+IVIontVQSws9SKwA=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                        "joi": "5.1.0"
-                    },
-                    "dependencies": {
-                        "joi": {
-                            "version": "5.1.0",
-                            "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
-                            "integrity": "sha1-FSrQfbjunGQBmX/1/SwSiWBwv1g=",
-                            "dev": true,
-                            "requires": {
-                                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                                "isemail": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-                                "moment": "2.19.1",
-                                "topo": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
-                            }
-                        }
-                    }
-                },
-                "hoek": {
-                    "version": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                    "integrity": "sha1-gSEWkfUqWoNa5J7b8eickANHaqQ=",
-                    "dev": true
-                },
-                "inert": {
-                    "version": "https://registry.npmjs.org/inert/-/inert-2.1.5.tgz",
-                    "integrity": "sha1-eybZTEHGLAPsHU726LRe1WuDSFk=",
-                    "dev": true,
-                    "requires": {
-                        "ammo": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz",
-                        "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                        "items": "https://registry.npmjs.org/items/-/items-1.1.0.tgz",
-                        "joi": "https://registry.npmjs.org/joi/-/joi-6.4.1.tgz",
-                        "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
-                    },
-                    "dependencies": {
-                        "lru-cache": {
-                            "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
-                            "integrity": "sha1-JnUZDM0bBwHsL2UqTQ09QA12wN0=",
-                            "dev": true
-                        }
-                    }
-                },
-                "iron": {
-                    "version": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz",
-                    "integrity": "sha1-WR2RiiVAdTxEbY5DfNzwz6gBEU8=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                    }
-                },
-                "items": {
-                    "version": "https://registry.npmjs.org/items/-/items-1.1.0.tgz",
-                    "integrity": "sha1-rZ1VhAsimGDLPRYLMidMLUvZ4mI=",
-                    "dev": true
-                },
-                "joi": {
-                    "version": "https://registry.npmjs.org/joi/-/joi-6.4.1.tgz",
-                    "integrity": "sha1-9Q9CRTVgBo5jg9oVrC0w3Xzra24=",
-                    "dev": true,
-                    "requires": {
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                        "isemail": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
-                        "moment": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz",
-                        "topo": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
-                    },
-                    "dependencies": {
-                        "isemail": {
-                            "version": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
-                            "integrity": "sha1-4Mj23D9HCX53dzlcaJYnGqJWw7U=",
-                            "dev": true
-                        },
-                        "moment": {
-                            "version": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz",
-                            "integrity": "sha1-CruZ8wf2UhgwjGk17+KcV7Ggon8=",
-                            "dev": true
-                        }
-                    }
-                },
-                "kilt": {
-                    "version": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz",
-                    "integrity": "sha1-d7SmFjyn+lshN6iMFzNCFuwj1ds=",
-                    "dev": true,
-                    "requires": {
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                    }
-                },
-                "mimos": {
-                    "version": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
-                    "integrity": "sha1-wyQXF+dblZkr54esfdbbGptTmx4=",
-                    "dev": true,
-                    "requires": {
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.14.0.tgz"
-                    },
-                    "dependencies": {
-                        "mime-db": {
-                            "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.14.0.tgz",
-                            "integrity": "sha1-1WHxC27mbbUflK5leilRp0IX7YM=",
-                            "dev": true
-                        }
-                    }
-                },
-                "peekaboo": {
-                    "version": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz",
-                    "integrity": "sha1-wNspJq1lTSygH3ymUKtFkadk/EI=",
-                    "dev": true
-                },
-                "qs": {
-                    "version": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-                    "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc=",
-                    "dev": true
-                },
-                "shot": {
-                    "version": "https://registry.npmjs.org/shot/-/shot-1.5.3.tgz",
-                    "integrity": "sha1-SGEHREO8VHLCNRthpGtOrsAH9Xo=",
-                    "dev": true,
-                    "requires": {
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                    }
-                },
-                "statehood": {
-                    "version": "https://registry.npmjs.org/statehood/-/statehood-2.1.1.tgz",
-                    "integrity": "sha1-AfFwtmxeklqvZ5qdMiulkYb8AAk=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                        "iron": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz",
-                        "items": "https://registry.npmjs.org/items/-/items-1.1.0.tgz",
-                        "joi": "https://registry.npmjs.org/joi/-/joi-6.4.1.tgz"
-                    }
-                },
-                "subtext": {
-                    "version": "https://registry.npmjs.org/subtext/-/subtext-1.1.1.tgz",
-                    "integrity": "sha1-DJGCWuZdUXhVWT2DHjPvdaKEFWs=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                        "content": "https://registry.npmjs.org/content/-/content-1.0.1.tgz",
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                        "pez": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
-                        "qs": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-                        "wreck": "https://registry.npmjs.org/wreck/-/wreck-6.0.0.tgz"
-                    },
-                    "dependencies": {
-                        "content": {
-                            "version": "https://registry.npmjs.org/content/-/content-1.0.1.tgz",
-                            "integrity": "sha1-gD60s7eJVGD9jGnGhMd1RmmvG6E=",
-                            "dev": true,
-                            "requires": {
-                                "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                            }
-                        },
-                        "pez": {
-                            "version": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
-                            "integrity": "sha1-hEMYpc5wku7d/6KV4YB5rHefoBg=",
-                            "dev": true,
-                            "requires": {
-                                "b64": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz",
-                                "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                                "content": "https://registry.npmjs.org/content/-/content-1.0.1.tgz",
-                                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                                "nigel": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz"
-                            },
-                            "dependencies": {
-                                "b64": {
-                                    "version": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz",
-                                    "integrity": "sha1-tZlbJPR+v9nxMQF6bntdZHVvtvM=",
-                                    "dev": true,
-                                    "requires": {
-                                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                                    }
-                                },
-                                "nigel": {
-                                    "version": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
-                                    "integrity": "sha1-RjmJr4gSePuqHTzJOCPb0XtDYKE=",
-                                    "dev": true,
-                                    "requires": {
-                                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                                        "vise": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz"
-                                    },
-                                    "dependencies": {
-                                        "vise": {
-                                            "version": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz",
-                                            "integrity": "sha1-KDRb5N5aNB4V/SgW/Z6j5zA+jfM=",
-                                            "dev": true,
-                                            "requires": {
-                                                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "topo": {
-                    "version": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz",
-                    "integrity": "sha1-QhV8N8HeTTeIPM3R1skChHqGDbk=",
-                    "dev": true,
-                    "requires": {
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                    }
-                },
-                "vision": {
-                    "version": "https://registry.npmjs.org/vision/-/vision-2.0.1.tgz",
-                    "integrity": "sha1-0BIlW6buQm0GlqNOHfMy/sVeZzw=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                        "items": "https://registry.npmjs.org/items/-/items-1.1.0.tgz",
-                        "joi": "https://registry.npmjs.org/joi/-/joi-6.4.1.tgz"
-                    }
-                },
-                "wreck": {
-                    "version": "https://registry.npmjs.org/wreck/-/wreck-6.0.0.tgz",
-                    "integrity": "sha1-T0CGaWHl14rOBPMqa38x8/PFFjg=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                    }
-                }
-            }
-        },
-        "har-schema": {
-            "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-            "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-        },
-        "har-validator": {
-            "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-            "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-            "requires": {
-                "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                "har-schema": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
-            }
-        },
-        "has-ansi": {
-            "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-            }
-        },
-        "has-flag": {
-            "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-            "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-            "dev": true
-        },
-        "has-gulplog": {
-            "version": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-            "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-            "dev": true,
-            "requires": {
-                "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
-            }
-        },
-        "has-unicode": {
-            "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-        },
-        "hasha": {
-            "version": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
-            "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
-            "dev": true,
-            "requires": {
-                "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-            }
-        },
-        "hawk": {
-            "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-            "requires": {
-                "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-            }
-        },
-        "hoek": {
-            "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-        },
-        "home-or-tmp": {
-            "version": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-            "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-            "dev": true,
-            "requires": {
-                "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-            }
-        },
-        "homedir-polyfill": {
-            "version": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-            "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-            "dev": true,
-            "requires": {
-                "parse-passwd": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz"
-            }
-        },
-        "hosted-git-info": {
-            "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-            "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
-            "dev": true
-        },
-        "hr": {
-            "version": "https://registry.npmjs.org/hr/-/hr-0.1.3.tgz",
-            "integrity": "sha1-2aow9ZKdq/0LZbo5WTij4YTbyv4=",
-            "dev": true
-        },
-        "htmlparser2": {
-            "version": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-            "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
-            "requires": {
-                "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-                "domhandler": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-                "domutils": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-                "entities": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
-            },
-            "dependencies": {
-                "domutils": {
-                    "version": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-                    "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-                    "requires": {
-                        "dom-serializer": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-                        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-                    }
-                },
-                "entities": {
-                    "version": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-                    "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
-                },
-                "isarray": {
-                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "requires": {
-                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                },
-                "string_decoder": {
-                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                }
-            }
-        },
-        "http-signature": {
-            "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-            "requires": {
-                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz"
-            }
-        },
-        "http2": {
-            "version": "https://github.com/node-apn/node-http2/archive/apn-2.1.4.tar.gz",
-            "integrity": "sha1-gzPe4tbgCJFSzvrTD0HO1QL5w2Y="
-        },
-        "https-proxy-agent": {
-            "version": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-            "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-            "dev": true,
-            "requires": {
-                "agent-base": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-                "debug": "2.6.9",
-                "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
-            }
-        },
-        "i": {
-            "version": "https://registry.npmjs.org/i/-/i-0.3.5.tgz",
-            "integrity": "sha1-HSuFQVjsgWkRPGy39raAHpniEdU=",
-            "dev": true
-        },
-        "iconv-lite": {
-            "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz",
-            "integrity": "sha1-T9qjs4rLwsAxsEXQ7c3+HsqxjI0=",
-            "dev": true
-        },
-        "indent-string": {
-            "version": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-            "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-            "dev": true,
-            "requires": {
-                "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
-            }
-        },
-        "inflight": {
-            "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "requires": {
-                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-            }
-        },
-        "inherits": {
-            "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "ini": {
-            "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-            "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
-        },
-        "inquirer": {
-            "version": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
-            "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
-            "dev": true,
-            "requires": {
-                "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-                "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-                "external-editor": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
-                "figures": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-                "run-async": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-                "rx": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-                "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-            },
-            "dependencies": {
-                "figures": {
-                    "version": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-                    "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-                    "dev": true,
-                    "requires": {
-                        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    }
-                },
-                "is-fullwidth-code-point": {
-                    "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-                    "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-                    }
-                }
-            }
-        },
-        "inquirer-confirm": {
-            "version": "https://registry.npmjs.org/inquirer-confirm/-/inquirer-confirm-0.2.2.tgz",
-            "integrity": "sha1-b0BtA3v52eRV7w+VOSnzV/6aiEg=",
-            "dev": true,
-            "requires": {
-                "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz",
-                "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.2.tgz"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                    "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
-                    "dev": true
-                },
-                "bluebird": {
-                    "version": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz",
-                    "integrity": "sha1-FKLnXwVIMj3DWqRA2SAHyhVOlnw=",
-                    "dev": true
-                },
-                "cli-width": {
-                    "version": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
-                    "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
-                    "dev": true
-                },
-                "figures": {
-                    "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-                    "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-                    "dev": true,
-                    "requires": {
-                        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                    }
-                },
-                "inquirer": {
-                    "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.2.tgz",
-                    "integrity": "sha1-QVhlSOHF2bP4HfcyUDS6rKtvWKs=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                        "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
-                        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-                        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                        "readline2": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-                        "rx": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
-                        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                    }
-                },
-                "lodash": {
-                    "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-                    "dev": true
-                },
-                "mute-stream": {
-                    "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
-                    "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
-                    "dev": true
-                },
-                "readline2": {
-                    "version": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-                    "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
-                    "dev": true,
-                    "requires": {
-                        "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
-                        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
-                    }
-                },
-                "rx": {
-                    "version": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
-                    "integrity": "sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                    "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                    }
-                }
-            }
-        },
-        "interpret": {
-            "version": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-            "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
-            "dev": true
-        },
-        "invariant": {
-            "version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-            "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-            "dev": true,
-            "requires": {
-                "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
-            }
-        },
-        "is": {
-            "version": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
-            "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
-            "dev": true
-        },
-        "is-absolute": {
-            "version": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-            "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
-            "dev": true,
-            "requires": {
-                "is-relative": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
-            }
-        },
-        "is-arrayish": {
-            "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-            "dev": true
-        },
-        "is-binary-path": {
-            "version": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-            "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-            "dev": true,
-            "requires": {
-                "binary-extensions": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
-            }
-        },
-        "is-buffer": {
-            "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-            "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-            "dev": true
-        },
-        "is-builtin-module": {
-            "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-            "dev": true,
-            "requires": {
-                "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-            }
-        },
-        "is-dotfile": {
-            "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-            "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
-            "dev": true
-        },
-        "is-equal-shallow": {
-            "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true,
-            "requires": {
-                "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-            }
-        },
-        "is-extendable": {
-            "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-            "dev": true
-        },
-        "is-extglob": {
-            "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-            "dev": true
-        },
-        "is-finite": {
-            "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-            "dev": true,
-            "requires": {
-                "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-            }
-        },
-        "is-fullwidth-code-point": {
-            "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "requires": {
-                "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-            }
-        },
-        "is-generator": {
-            "version": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
-            "integrity": "sha1-wUwhBX7TbjKNuANHlmxpP4hjifM=",
-            "dev": true
-        },
-        "is-glob": {
-            "version": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
-            "integrity": "sha1-tMZLgwPTkRRJKkYNNkzPsNPAoEU=",
-            "dev": true
-        },
-        "is-my-json-valid": {
-            "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-            "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-            "dev": true,
-            "requires": {
-                "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-        },
-        "is-number": {
-            "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-            "dev": true,
-            "requires": {
-                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz"
-            }
-        },
-        "is-obj": {
-            "version": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-            "dev": true
-        },
-        "is-posix-bracket": {
-            "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-            "dev": true
-        },
-        "is-primitive": {
-            "version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-            "dev": true
-        },
-        "is-promise": {
-            "version": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-            "dev": true
-        },
-        "is-property": {
-            "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-            "dev": true
-        },
-        "is-relative": {
-            "version": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-            "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
-            "dev": true
-        },
-        "is-stream": {
-            "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-            "dev": true
-        },
-        "is-subset": {
-            "version": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-            "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-            "dev": true
-        },
-        "is-text-path": {
-            "version": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-            "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
-            "dev": true,
-            "requires": {
-                "text-extensions": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.4.0.tgz"
-            }
-        },
-        "is-typedarray": {
-            "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
-        "is-unc-path": {
-            "version": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
-            "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
-            "dev": true,
-            "requires": {
-                "unc-path-regex": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz"
-            }
-        },
-        "is-utf8": {
-            "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-            "dev": true
-        },
-        "is-windows": {
-            "version": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-            "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
-            "dev": true
-        },
+  "name": "part-up",
+  "version": "2.37.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "add-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
+      "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
+      "dev": true
+    },
+    "agent-base": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "dev": true,
+      "dependencies": {
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+      "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI="
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true
+    },
+    "always-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/always-error/-/always-error-1.0.0.tgz",
+      "integrity": "sha1-lchAQs+obzjIbKbCzELAoBA0QbI=",
+      "dev": true
+    },
+    "am-i-a-dependency": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/am-i-a-dependency/-/am-i-a-dependency-1.1.2.tgz",
+      "integrity": "sha1-+dNCIwTW9kL4IeTEB1ZQNfYWfx8=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-cyan": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "dev": true
+    },
+    "ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "any-shell-escape": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/any-shell-escape/-/any-shell-escape-0.1.1.tgz",
+      "integrity": "sha1-1Vq5ciRMcaml4asIefML8RCAaVk=",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "dev": true
+    },
+    "apn": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/apn/-/apn-2.1.5.tgz",
+      "integrity": "sha1-Xgtxk8ZGpV+hZYdBGNmvf3zP1ts="
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "archiver": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.0.tgz",
+      "integrity": "sha1-0t8ujVdzqCwdzOklzMQUUOqZmv0=",
+      "dev": true
+    },
+    "archiver-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "dev": true
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0="
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+      "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+      "dev": true
+    },
+    "array-differ": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+      "dev": true
+    },
+    "array-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+      "dev": true
+    },
+    "array-parallel": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
+      "integrity": "sha1-j3hTCJJu1apHjEfmTRszS2wMlH0="
+    },
+    "array-series": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz",
+      "integrity": "sha1-3103v8XC7wdV4qpPkv6ufUtaly8="
+    },
+    "array-slice": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+      "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+      "dev": true
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw=="
+    },
+    "async-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "atob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+      "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true
+    },
+    "babel-core": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "dev": true
+    },
+    "babel-generator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+      "dev": true
+    },
+    "babel-helper-bindify-decorators": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
+      "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
+      "dev": true
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "dev": true
+    },
+    "babel-helper-define-map": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "dev": true
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true
+    },
+    "babel-helper-explode-class": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
+      "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
+      "dev": true
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "dev": true
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "dev": true
+    },
+    "babel-helper-regex": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "dev": true
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "dev": true
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
+    },
+    "babel-plugin-syntax-async-generators": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+      "dev": true
+    },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+      "dev": true
+    },
+    "babel-plugin-syntax-decorators": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+      "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
+      "dev": true
+    },
+    "babel-plugin-syntax-dynamic-import": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+      "dev": true
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
+    },
+    "babel-plugin-transform-async-generator-functions": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
+      "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+      "dev": true
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "dev": true
+    },
+    "babel-plugin-transform-decorators": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
+      "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "dev": true
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "dev": true
+    },
+    "babel-plugin-transform-runtime": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+      "dev": true
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
+    "babel-preset-es2015": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+      "dev": true
+    },
+    "babel-preset-stage-2": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
+      "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+      "dev": true
+    },
+    "babel-preset-stage-3": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
+      "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+      "dev": true
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
+    },
+    "bcrypt": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-1.0.3.tgz",
+      "integrity": "sha512-pRyDdo73C8Nim3jwFJ7DWe3TZCgwDfWZ6nHS5LSdU77kWbj1frruvdndP02AOavtD4y8v6Fp2dolbHgp4SDrfg=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true
+    },
+    "beeper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+      "dev": true
+    },
+    "bl": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+      "dependencies": {
         "isarray": {
-            "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "isemail": {
-            "version": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-            "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
-        },
-        "isexe": {
-            "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-        },
-        "isobject": {
-            "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-            "dev": true,
-            "requires": {
-                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            }
-        },
-        "isstream": {
-            "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-        },
-        "jasmine": {
-            "version": "https://registry.npmjs.org/jasmine/-/jasmine-2.6.0.tgz",
-            "integrity": "sha1-ayLnCIPo5YnUVjRhU7TSBt2+IX8=",
-            "dev": true,
-            "requires": {
-                "exit": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                "jasmine-core": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.2.tgz"
-            }
-        },
-        "jasmine-core": {
-            "version": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.2.tgz",
-            "integrity": "sha1-dOoffPQoaRryARB9YxI0AnoJ2qs=",
-            "dev": true
-        },
-        "jodid25519": {
-            "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-            "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-            "optional": true,
-            "requires": {
-                "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-            }
-        },
-        "joi": {
-            "version": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-            "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-            "requires": {
-                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                "isemail": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-                "moment": "2.19.1",
-                "topo": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
-            }
-        },
-        "js-tokens": {
-            "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-            "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
-            "dev": true
-        },
-        "jsbn": {
-            "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "optional": true
-        },
-        "jschardet": {
-            "version": "https://registry.npmjs.org/jschardet/-/jschardet-1.4.2.tgz",
-            "integrity": "sha1-KqEH8UKvQSHRRWWdRPUIMJYeaZo=",
-            "dev": true
-        },
-        "jsesc": {
-            "version": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-            "dev": true
-        },
-        "json-schema": {
-            "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-        },
-        "json-stable-stringify": {
-            "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-            "requires": {
-                "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-            }
-        },
-        "json-stringify-safe": {
-            "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-        },
-        "json2yaml": {
-            "version": "https://registry.npmjs.org/json2yaml/-/json2yaml-1.1.0.tgz",
-            "integrity": "sha1-VBTZB/mBZYa4DFE+wuOusquBmmw=",
-            "dev": true,
-            "requires": {
-                "remedial": "https://registry.npmjs.org/remedial/-/remedial-1.0.7.tgz"
-            }
-        },
-        "json3": {
-            "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-            "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-            "dev": true
-        },
-        "json5": {
-            "version": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-            "dev": true
-        },
-        "jsonfile": {
-            "version": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-            "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-            }
-        },
-        "jsonify": {
-            "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-        },
-        "jsonparse": {
-            "version": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz",
-            "integrity": "sha1-hfwkWx2SWazGlBlguQWt9k594Og=",
-            "dev": true
-        },
-        "jsonpointer": {
-            "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-            "dev": true
-        },
-        "jsonwebtoken": {
-            "version": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.1.tgz",
-            "integrity": "sha1-fKMk9SFfi+A5zTWmxFu4y3SkSPs=",
-            "requires": {
-                "joi": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-                "jws": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
-                "lodash.once": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-                "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-        },
-        "jsprim": {
-            "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-            "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-            "requires": {
-                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
-            }
-        },
-        "jwa": {
-            "version": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
-            "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
-            "requires": {
-                "base64url": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-                "buffer-equal-constant-time": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-                "ecdsa-sig-formatter": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
-                "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-            }
-        },
-        "jws": {
-            "version": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
-            "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
-            "requires": {
-                "base64url": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-                "jwa": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
-                "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-            }
-        },
-        "kew": {
-            "version": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
-            "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
-            "dev": true
-        },
-        "kind-of": {
-            "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
-            "integrity": "sha1-tYq+TVwEStM3JqjBUltIz4kb/wc=",
-            "dev": true,
-            "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-            }
-        },
-        "klaw": {
-            "version": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-            "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-            }
-        },
-        "lazy-ass": {
-            "version": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-            "integrity": "sha1-yhW+JDx8R1uFZc2/oPnC83TyoB0=",
-            "dev": true
-        },
-        "lazy-cache": {
-            "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-            "dev": true,
-            "optional": true
-        },
-        "lazystream": {
-            "version": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
-            }
-        },
-        "liftoff": {
-            "version": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
-            "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
-            "dev": true,
-            "requires": {
-                "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-                "findup-sync": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz",
-                "fined": "https://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
-                "flagged-respawn": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
-                "lodash.isplainobject": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-                "lodash.isstring": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-                "lodash.mapvalues": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-                "rechoir": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-                "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz"
-            }
-        },
-        "load-json-file": {
-            "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-            }
-        },
-        "lodash": {
-            "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        },
-        "lodash._baseassign": {
-            "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-            "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-            "dev": true,
-            "requires": {
-                "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-            }
-        },
-        "lodash._basecopy": {
-            "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-            "dev": true
-        },
-        "lodash._basecreate": {
-            "version": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-            "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-            "dev": true
-        },
-        "lodash._basetostring": {
-            "version": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-            "dev": true
-        },
-        "lodash._basevalues": {
-            "version": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-            "dev": true
-        },
-        "lodash._escapehtmlchar": {
-            "version": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
-            "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
-            "dev": true,
-            "requires": {
-                "lodash._htmlescapes": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
-            }
-        },
-        "lodash._escapestringchar": {
-            "version": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
-            "integrity": "sha1-7P4iYYoq3lC/7qQ5N+Ud9m8O23I=",
-            "dev": true
-        },
-        "lodash._getnative": {
-            "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-            "dev": true
-        },
-        "lodash._htmlescapes": {
-            "version": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-            "integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs=",
-            "dev": true
-        },
-        "lodash._isiterateecall": {
-            "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-            "dev": true
-        },
-        "lodash._isnative": {
-            "version": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-            "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
-            "dev": true
-        },
-        "lodash._objecttypes": {
-            "version": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-            "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
-            "dev": true
-        },
-        "lodash._reescape": {
-            "version": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-            "dev": true
-        },
-        "lodash._reevaluate": {
-            "version": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-            "dev": true
-        },
-        "lodash._reinterpolate": {
-            "version": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-            "dev": true
-        },
-        "lodash._reunescapedhtml": {
-            "version": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
-            "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
-            "dev": true,
-            "requires": {
-                "lodash._htmlescapes": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-                "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
-            },
-            "dependencies": {
-                "lodash.keys": {
-                    "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                    "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-                        "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-                        "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
-                    }
-                }
-            }
-        },
-        "lodash._root": {
-            "version": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-            "dev": true
-        },
-        "lodash._shimkeys": {
-            "version": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-            "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
-            "dev": true,
-            "requires": {
-                "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-            }
-        },
-        "lodash.assignwith": {
-            "version": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
-            "integrity": "sha1-EnqX8CrcQXUalU0ksN4X4QDgOOs=",
-            "dev": true
-        },
-        "lodash.create": {
-            "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-            "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-            "dev": true,
-            "requires": {
-                "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-                "lodash._basecreate": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-                "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-            }
-        },
-        "lodash.defaults": {
-            "version": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
-            "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
-            "dev": true,
-            "requires": {
-                "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
-            },
-            "dependencies": {
-                "lodash.keys": {
-                    "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                    "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-                        "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-                        "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
-                    }
-                }
-            }
-        },
-        "lodash.escape": {
-            "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-            "dev": true,
-            "requires": {
-                "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
-            }
-        },
-        "lodash.isarguments": {
-            "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-            "dev": true
-        },
-        "lodash.isarray": {
-            "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-            "dev": true
-        },
-        "lodash.isempty": {
-            "version": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-            "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
-            "dev": true
-        },
-        "lodash.isobject": {
-            "version": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-            "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
-            "dev": true,
-            "requires": {
-                "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-            }
-        },
-        "lodash.isplainobject": {
-            "version": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-            "dev": true
-        },
-        "lodash.isstring": {
-            "version": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-            "dev": true
-        },
-        "lodash.keys": {
-            "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "dev": true,
-            "requires": {
-                "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-                "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-            }
-        },
-        "lodash.map": {
-            "version": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-            "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
-            "dev": true
-        },
-        "lodash.mapvalues": {
-            "version": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-            "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
-            "dev": true
-        },
-        "lodash.merge": {
-            "version": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-            "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
-            "dev": true
-        },
-        "lodash.once": {
-            "version": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-            "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
-        },
-        "lodash.pick": {
-            "version": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-            "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
-            "dev": true
-        },
-        "lodash.restparam": {
-            "version": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-            "dev": true
-        },
-        "lodash.template": {
-            "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-            "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-            "dev": true,
-            "requires": {
-                "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-                "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz"
-            }
-        },
-        "lodash.templatesettings": {
-            "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-            "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-            "dev": true,
-            "requires": {
-                "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
-            }
-        },
-        "lodash.values": {
-            "version": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
-            "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
-            "dev": true,
-            "requires": {
-                "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
-            },
-            "dependencies": {
-                "lodash.keys": {
-                    "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                    "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-                        "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-                        "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
-                    }
-                }
-            }
-        },
-        "loglevel": {
-            "version": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.1.tgz",
-            "integrity": "sha1-lbOD+Ro8J1b9SrCTZn5DCRYfK80=",
-            "dev": true
-        },
-        "longest": {
-            "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-            "dev": true
-        },
-        "loose-envify": {
-            "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-            "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-            "dev": true,
-            "requires": {
-                "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-            }
-        },
-        "loud-rejection": {
-            "version": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-            "dev": true,
-            "requires": {
-                "currently-unhandled": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-                "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-            }
-        },
-        "lower-case": {
-            "version": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-            "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-            "dev": true
-        },
-        "lru-cache": {
-            "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-            "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-            "requires": {
-                "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
-            }
-        },
-        "map-cache": {
-            "version": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-            "dev": true
-        },
-        "map-obj": {
-            "version": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-            "dev": true
-        },
-        "map-stream": {
-            "version": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-            "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
-            "dev": true
-        },
-        "meow": {
-            "version": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-            "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-            "dev": true,
-            "requires": {
-                "camelcase-keys": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-                "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                "loud-rejection": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-                "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                "redent": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                "trim-newlines": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
-            }
-        },
-        "merge": {
-            "version": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-            "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
-            "dev": true
-        },
-        "meteor-promise": {
-            "version": "https://registry.npmjs.org/meteor-promise/-/meteor-promise-0.8.4.tgz",
-            "integrity": "sha1-kCnj9ZaFTQT/NGxuGfMByKXlU7A=",
-            "dev": true
-        },
-        "micromatch": {
-            "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-            "dev": true,
-            "requires": {
-                "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                "braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                "expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                "extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                "filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
-                "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-                "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-                "parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
-            },
-            "dependencies": {
-                "is-glob": {
-                    "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                    }
-                }
-            }
-        },
-        "mime": {
-            "version": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-            "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
-            "dev": true
-        },
-        "mime-db": {
-            "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-            "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
-        },
-        "mime-types": {
-            "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-            "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-            "requires": {
-                "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
-            }
-        },
-        "mimic-fn": {
-            "version": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-            "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-            "dev": true
-        },
-        "minimatch": {
-            "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-            "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-            "requires": {
-                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
-            }
-        },
-        "minimist": {
-            "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        },
-        "mkdirp": {
-            "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "requires": {
-                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-        },
-        "mocha": {
-            "version": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-            "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
-            "dev": true,
-            "requires": {
-                "browser-stdout": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-                "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                "debug": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-                "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                "growl": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-                "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-                "lodash.create": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-                    "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-                    "dev": true,
-                    "requires": {
-                        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                    }
-                },
-                "ms": {
-                    "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                    "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-                    "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                    }
-                }
-            }
-        },
-        "modify-values": {
-            "version": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
-            "integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI=",
-            "dev": true
-        },
-        "moment": {
-            "version": "2.19.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz",
-            "integrity": "sha1-VtoaLRy/AdOLfhr8McELz6GSkWc="
-        },
-        "mout": {
-            "version": "https://registry.npmjs.org/mout/-/mout-1.0.0.tgz",
-            "integrity": "sha1-m98dSvV9ZtR8s1OmM1oygQmOFQE="
-        },
-        "ms": {
-            "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "multipipe": {
-            "version": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-            "dev": true,
-            "requires": {
-                "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
-            }
-        },
-        "mute-stream": {
-            "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-            "dev": true
-        },
-        "nan": {
-            "version": "https://registry.npmjs.org/nan/-/nan-2.5.0.tgz",
-            "integrity": "sha1-qo8eNFMdgH6eJ3VbI0tKbsDBUqg="
-        },
-        "natives": {
-            "version": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
-            "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
-            "dev": true
-        },
-        "ncp": {
-            "version": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
-            "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
-            "dev": true
-        },
-        "no-case": {
-            "version": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
-            "integrity": "sha1-euuhxzpSGEJlVUt9wDuvcg34AIE=",
-            "dev": true,
-            "requires": {
-                "lower-case": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz"
-            }
-        },
-        "node-forge": {
-            "version": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.49.tgz",
-            "integrity": "sha1-8e6V1ddGI5OP4Z1piqWibVTS9g8="
-        },
-        "node-metainspector": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/node-metainspector/-/node-metainspector-1.3.0.tgz",
-            "integrity": "sha1-4SoiJyMmYz7U1STxsrQG6x3NU18=",
-            "requires": {
-                "cheerio": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-                "uri-js": "https://registry.npmjs.org/uri-js/-/uri-js-2.1.1.tgz"
-            }
-        },
-        "node-notifier": {
-            "version": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
-            "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
-            "dev": true,
-            "requires": {
-                "growly": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                "shellwords": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
-                "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
-            }
-        },
-        "node-pre-gyp": {
-            "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz",
-            "integrity": "sha1-/EUrN25zGbPSVfXzSFPvb9j+H9U=",
-            "requires": {
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-                "rc": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-                "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-                "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-                "tar-pack": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz"
-            }
-        },
-        "node.extend": {
-            "version": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
-            "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
-            "dev": true,
-            "requires": {
-                "is": "https://registry.npmjs.org/is/-/is-3.2.1.tgz"
-            }
-        },
-        "nopt": {
-            "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-            "requires": {
-                "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
-            }
-        },
-        "normalize-package-data": {
-            "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-            "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
-            "dev": true,
-            "requires": {
-                "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-                "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-            }
-        },
-        "normalize-path": {
-            "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-            "dev": true,
-            "requires": {
-                "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz"
-            }
-        },
-        "npm-build-tools": {
-            "version": "https://registry.npmjs.org/npm-build-tools/-/npm-build-tools-2.2.5.tgz",
-            "integrity": "sha1-/EqZ8g6CO2uULQtXy7IejQAMRfc=",
-            "dev": true,
-            "requires": {
-                "chokidar": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.6.tgz",
-                "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "dev": true,
-                    "requires": {
-                        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-                    }
-                }
-            }
-        },
-        "npm-install-package": {
-            "version": "https://registry.npmjs.org/npm-install-package/-/npm-install-package-2.1.0.tgz",
-            "integrity": "sha1-1+/jz816sAYUuJbqUxGdyaslkSU=",
-            "dev": true
-        },
-        "npmlog": {
-            "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-            "integrity": "sha1-3Fm+6F9k8A7UJO+yrweD3yXRwLU=",
-            "requires": {
-                "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-                "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-                "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-            }
-        },
-        "nth-check": {
-            "version": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-            "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-            "requires": {
-                "boolbase": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
-            }
-        },
-        "number-is-nan": {
-            "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-        },
-        "oauth-sign": {
-            "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-        },
-        "object-assign": {
-            "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "object-keys": {
-            "version": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-            "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-            "dev": true
-        },
-        "object.assign": {
-            "version": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
-            "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
-            "dev": true,
-            "requires": {
-                "define-properties": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-                "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-                "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
-            }
-        },
-        "object.omit": {
-            "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "dev": true,
-            "requires": {
-                "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-                "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-            }
-        },
-        "once": {
-            "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "requires": {
-                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-            }
-        },
-        "onetime": {
-            "version": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-            "dev": true,
-            "requires": {
-                "mimic-fn": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz"
-            }
-        },
-        "optimist": {
-            "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-            "dev": true,
-            "requires": {
-                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-            }
-        },
-        "orchestrator": {
-            "version": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-            "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
-            "dev": true,
-            "requires": {
-                "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-                "sequencify": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-                "stream-consume": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
-            },
-            "dependencies": {
-                "end-of-stream": {
-                    "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-                    "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
-                    "dev": true,
-                    "requires": {
-                        "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
-                    }
-                },
-                "once": {
-                    "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                    "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-                    "dev": true,
-                    "requires": {
-                        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                }
-            }
-        },
-        "ordered-read-streams": {
-            "version": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-            "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
-            "dev": true
-        },
-        "os-homedir": {
-            "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-            "dev": true
-        },
-        "os-shim": {
-            "version": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-            "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
-            "dev": true
-        },
-        "os-tmpdir": {
-            "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-            "dev": true
-        },
-        "pad-right": {
-            "version": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
-            "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
-            "dev": true,
-            "requires": {
-                "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-            }
-        },
-        "parse-filepath": {
-            "version": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
-            "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
-            "dev": true,
-            "requires": {
-                "is-absolute": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
-                "map-cache": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-                "path-root": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz"
-            },
-            "dependencies": {
-                "is-absolute": {
-                    "version": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
-                    "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
-                    "dev": true,
-                    "requires": {
-                        "is-relative": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-                        "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
-                    }
-                },
-                "is-relative": {
-                    "version": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-                    "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
-                    "dev": true,
-                    "requires": {
-                        "is-unc-path": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz"
-                    }
-                }
-            }
-        },
-        "parse-github-repo-url": {
-            "version": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.0.tgz",
-            "integrity": "sha1-KGxT4smWLgZBZJ7jrJUI/KTdlZw=",
-            "dev": true
-        },
-        "parse-glob": {
-            "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "dev": true,
-            "requires": {
-                "glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                "is-dotfile": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-            },
-            "dependencies": {
-                "is-glob": {
-                    "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                    }
-                }
-            }
-        },
-        "parse-json": {
-            "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-            "dev": true,
-            "requires": {
-                "error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
-            }
-        },
-        "parse-passwd": {
-            "version": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-            "dev": true
-        },
-        "part-up-js-helpers": {
-            "version": "git://github.com/part-up/js-helpers.git#2b71a56642ddbb545ef5f002c5197effaf6b99a3",
-            "requires": {
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "moment": "2.19.1",
-                "mout": "https://registry.npmjs.org/mout/-/mout-1.0.0.tgz",
-                "powercheck": "https://registry.npmjs.org/powercheck/-/powercheck-1.1.0.tgz"
-            }
-        },
-        "part-up-js-models": {
-            "version": "git://github.com/part-up/js-models.git#a6ea85deb725bbebd15e789fed059016e5c05b40",
-            "requires": {
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "moment": "2.19.1",
-                "mout": "https://registry.npmjs.org/mout/-/mout-1.0.0.tgz",
-                "part-up-js-helpers": "git://github.com/part-up/js-helpers.git#2b71a56642ddbb545ef5f002c5197effaf6b99a3",
-                "powercheck": "https://registry.npmjs.org/powercheck/-/powercheck-1.1.0.tgz"
-            }
-        },
-        "path-exists": {
-            "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-            "dev": true,
-            "requires": {
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-            }
-        },
-        "path-is-absolute": {
-            "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-        },
-        "path-parse": {
-            "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-            "dev": true
-        },
-        "path-root": {
-            "version": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
-            "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
-            "dev": true,
-            "requires": {
-                "path-root-regex": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz"
-            }
-        },
-        "path-root-regex": {
-            "version": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-            "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
-            "dev": true
-        },
-        "path-type": {
-            "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-            }
-        },
-        "pend": {
-            "version": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-            "dev": true
-        },
-        "performance-now": {
-            "version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-            "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-        },
-        "phantomjs-prebuilt": {
-            "version": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.13.tgz",
-            "integrity": "sha1-ZlVq2ell2JPKWn3J52PffoaX920=",
-            "dev": true,
-            "requires": {
-                "es6-promise": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
-                "extract-zip": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
-                "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-                "hasha": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
-                "kew": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
-                "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-                "request": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
-                "request-progress": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
-                "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
-            },
-            "dependencies": {
-                "bl": {
-                    "version": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-                    "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-                    }
-                },
-                "caseless": {
-                    "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                    "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-                    "dev": true
-                },
-                "form-data": {
-                    "version": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-                    "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
-                    "dev": true,
-                    "requires": {
-                        "async": "https://registry.npmjs.org/async/-/async-2.4.0.tgz",
-                        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
-                    }
-                },
-                "fs-extra": {
-                    "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-                    "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                        "jsonfile": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-                        "klaw": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-                        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
-                    }
-                },
-                "har-validator": {
-                    "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                    "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-                        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-                    }
-                },
-                "node-uuid": {
-                    "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-                    "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-                    "dev": true
-                },
-                "qs": {
-                    "version": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
-                    "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                },
-                "request": {
-                    "version": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
-                    "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
-                    "dev": true,
-                    "requires": {
-                        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                        "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-                        "bl": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-                        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-                        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                        "form-data": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-                        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                        "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-                        "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-                        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                        "qs": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
-                        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
-                    }
-                },
-                "string_decoder": {
-                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "tunnel-agent": {
-                    "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                    "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-                    "dev": true
-                }
-            }
-        },
-        "pify": {
-            "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true
-        },
-        "pinkie": {
-            "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
-        },
-        "pinkie-promise": {
-            "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
-            "requires": {
-                "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-            }
-        },
-        "pkginfo": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
-            "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
-        },
-        "plugin-error": {
-            "version": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
-            "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
-            "dev": true,
-            "requires": {
-                "ansi-cyan": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
-                "ansi-red": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
-                "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-                "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
-                "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-                    "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-                        "array-slice": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
-                    }
-                }
-            }
-        },
-        "plugin-log": {
-            "version": "https://registry.npmjs.org/plugin-log/-/plugin-log-0.1.0.tgz",
-            "integrity": "sha1-hgSc9qsQgzOYqTHzaJy67nteEzM=",
-            "dev": true,
-            "requires": {
-                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz"
-            }
-        },
-        "pluralize": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-5.0.0.tgz",
-            "integrity": "sha1-6LkHOvmgywLkwu+pW1W+u9vwEpk="
-        },
-        "pop-iterate": {
-            "version": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",
-            "integrity": "sha1-zqz9q0q/NT16DyqqLB/Hs/lBO6M=",
-            "dev": true
-        },
-        "powercheck": {
-            "version": "https://registry.npmjs.org/powercheck/-/powercheck-1.1.0.tgz",
-            "integrity": "sha1-dqNPb5hH1mZ36ssGUQ8WYofGA+A="
-        },
-        "pre-git": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/pre-git/-/pre-git-3.15.0.tgz",
-            "integrity": "sha1-3a272trFpG1ZROFq2BAgOPgTnIg=",
-            "dev": true,
-            "requires": {
-                "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                "check-more-types": "2.24.0",
-                "conventional-commit-message": "https://registry.npmjs.org/conventional-commit-message/-/conventional-commit-message-1.1.0.tgz",
-                "cz-conventional-changelog": "1.2.0",
-                "ggit": "1.15.1",
-                "inquirer": "0.12.0",
-                "lazy-ass": "1.6.0",
-                "require-relative": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-                "shelljs": "0.6.0",
-                "simple-commit-message": "https://registry.npmjs.org/simple-commit-message/-/simple-commit-message-2.2.1.tgz",
-                "validate-commit-msg": "https://registry.npmjs.org/validate-commit-msg/-/validate-commit-msg-2.11.1.tgz",
-                "word-wrap": "1.2.1"
-            },
-            "dependencies": {
-                "check-more-types": {
-                    "version": "2.24.0",
-                    "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
-                    "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
-                    "dev": true
-                },
-                "cli-cursor": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-                    "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-                    "dev": true,
-                    "requires": {
-                        "restore-cursor": "1.0.1"
-                    }
-                },
-                "cz-conventional-changelog": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-1.2.0.tgz",
-                    "integrity": "sha1-K8oElkyJGbI/P9aonvXmAIsxs/g=",
-                    "dev": true,
-                    "requires": {
-                        "conventional-commit-types": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.1.0.tgz",
-                        "lodash.map": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-                        "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                        "pad-right": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
-                        "right-pad": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
-                        "word-wrap": "1.2.1"
-                    }
-                },
-                "ggit": {
-                    "version": "1.15.1",
-                    "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.15.1.tgz",
-                    "integrity": "sha1-gNVS6OFxLJgF/luhzxGaTn472Zg=",
-                    "dev": true,
-                    "requires": {
-                        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-                        "chdir-promise": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.0.tgz",
-                        "check-more-types": "2.24.0",
-                        "cli-table": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-                        "colors": "1.1.2",
-                        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                        "d3-helpers": "https://registry.npmjs.org/d3-helpers/-/d3-helpers-0.3.0.tgz",
-                        "debug": "2.6.3",
-                        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                        "lazy-ass": "1.6.0",
-                        "lodash": "3.10.1",
-                        "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                        "q": "2.0.3",
-                        "quote": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
-                        "ramda": "https://registry.npmjs.org/ramda/-/ramda-0.9.1.tgz"
-                    },
-                    "dependencies": {
-                        "debug": {
-                            "version": "2.6.3",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-                            "integrity": "sha1-D364wwll7AjHKsz6ATDIt5mEFB0=",
-                            "dev": true,
-                            "requires": {
-                                "ms": "0.7.2"
-                            }
-                        }
-                    }
-                },
-                "inquirer": {
-                    "version": "0.12.0",
-                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-                    "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-                        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                        "cli-cursor": "1.0.2",
-                        "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-                        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-                        "lodash": "4.17.4",
-                        "readline2": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-                        "run-async": "0.1.0",
-                        "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-                        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                    },
-                    "dependencies": {
-                        "lodash": {
-                            "version": "4.17.4",
-                            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-                            "dev": true
-                        }
-                    }
-                },
-                "lazy-ass": {
-                    "version": "1.6.0",
-                    "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
-                    "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
-                    "dev": true
-                },
-                "lodash": {
-                    "version": "3.10.1",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-                    "dev": true
-                },
-                "ms": {
-                    "version": "0.7.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                    "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-                    "dev": true
-                },
-                "onetime": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-                    "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-                    "dev": true
-                },
-                "q": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
-                    "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
-                    "dev": true,
-                    "requires": {
-                        "asap": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-                        "pop-iterate": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",
-                        "weak-map": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz"
-                    }
-                },
-                "restore-cursor": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                    "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-                    "dev": true,
-                    "requires": {
-                        "exit-hook": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-                        "onetime": "1.1.0"
-                    }
-                },
-                "run-async": {
-                    "version": "0.1.0",
-                    "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-                    "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-                    "dev": true,
-                    "requires": {
-                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-                    }
-                },
-                "shelljs": {
-                    "version": "0.6.0",
-                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz",
-                    "integrity": "sha1-zh7YN7Sw5Vtew9q4QlGrnb3Ax+w=",
-                    "dev": true
-                },
-                "word-wrap": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.1.tgz",
-                    "integrity": "sha1-JI9Fm0ZdF5oXvEB8hU0xUdB+Rdg=",
-                    "dev": true
-                }
-            }
-        },
-        "preserve": {
-            "version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-            "dev": true
-        },
-        "pretty-hrtime": {
-            "version": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-            "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
-            "dev": true
-        },
-        "prettyjson": {
-            "version": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
-            "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
-            "dev": true,
-            "requires": {
-                "colors": "1.1.2",
-                "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
-            }
-        },
-        "private": {
-            "version": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-            "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
-            "dev": true
-        },
-        "process-nextick-args": {
-            "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "progress": {
-            "version": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-            "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-            "dev": true
-        },
-        "prompt": {
-            "version": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
-            "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
-            "dev": true,
-            "requires": {
-                "colors": "1.1.2",
-                "pkginfo": "0.4.1",
-                "read": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-                "revalidator": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
-                "utile": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
-                "winston": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-                    "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
-                    "dev": true
-                },
-                "winston": {
-                    "version": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
-                    "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
-                    "dev": true,
-                    "requires": {
-                        "async": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-                        "colors": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-                        "cycle": "1.0.3",
-                        "eyes": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-                        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                        "pkginfo": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-                        "stack-trace": "0.0.10"
-                    },
-                    "dependencies": {
-                        "colors": {
-                            "version": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-                            "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-                            "dev": true
-                        },
-                        "pkginfo": {
-                            "version": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-                            "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
-                            "dev": true
-                        }
-                    }
-                }
-            }
-        },
-        "pseudomap": {
-            "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-        },
-        "punycode": {
-            "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        },
-        "q": {
-            "version": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-            "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
-            "dev": true
-        },
-        "qs": {
-            "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-            "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-        },
-        "querystring": {
-            "version": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-            "dev": true
-        },
-        "quote": {
-            "version": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
-            "integrity": "sha1-EIOSF/bBNiuJGUBE0psjP9fzLwE=",
-            "dev": true
-        },
-        "ramda": {
-            "version": "https://registry.npmjs.org/ramda/-/ramda-0.9.1.tgz",
-            "integrity": "sha1-zJFNw6gsYI0AMJAgN4fD9oJsHYc=",
-            "dev": true
-        },
-        "randomatic": {
-            "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-            "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-            "dev": true,
-            "requires": {
-                "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz"
-            }
-        },
-        "rc": {
-            "version": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-            "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
-            "requires": {
-                "deep-extend": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                }
-            }
-        },
-        "read": {
-            "version": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-            "dev": true,
-            "requires": {
-                "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz"
-            }
-        },
-        "read-pkg": {
-            "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-            "dev": true,
-            "requires": {
-                "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-                "path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
-            }
-        },
-        "read-pkg-up": {
-            "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-            "dev": true,
-            "requires": {
-                "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
-            }
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
-            "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-            "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-            "requires": {
-                "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-                "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-            }
-        },
-        "readdirp": {
-            "version": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
-            "integrity": "sha1-xd5vyz3sgFI8HHARPxoZDYr4LIk=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "lru-cache": {
-                    "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                    "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                    "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                        "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                    }
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                },
-                "string_decoder": {
-                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                }
-            }
-        },
-        "readline2": {
-            "version": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-            "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-            "dev": true,
-            "requires": {
-                "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-            },
-            "dependencies": {
-                "mute-stream": {
-                    "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-                    "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-                    "dev": true
-                }
-            }
-        },
-        "rechoir": {
-            "version": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-            "dev": true,
-            "requires": {
-                "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz"
-            }
-        },
-        "redent": {
-            "version": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-            "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-            "dev": true,
-            "requires": {
-                "indent-string": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                "strip-indent": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-            }
-        },
-        "regenerate": {
-            "version": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-            "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
-            "dev": true
-        },
-        "regenerator-runtime": {
-            "version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-            "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-            "dev": true
-        },
-        "regenerator-transform": {
-            "version": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
-            "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-                "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
-            }
-        },
-        "regex-cache": {
-            "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-            "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-            "dev": true,
-            "requires": {
-                "is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-            }
-        },
-        "regexpu-core": {
-            "version": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-            "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-            "dev": true,
-            "requires": {
-                "regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-                "regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-                "regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
-            }
-        },
-        "regjsgen": {
-            "version": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-            "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-            "dev": true
-        },
-        "regjsparser": {
-            "version": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-            "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-            "dev": true,
-            "requires": {
-                "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
-            },
-            "dependencies": {
-                "jsesc": {
-                    "version": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-                    "dev": true
-                }
-            }
-        },
-        "remedial": {
-            "version": "https://registry.npmjs.org/remedial/-/remedial-1.0.7.tgz",
-            "integrity": "sha1-1mdEE6ZWdgB74A3UAJgJh7LDAME=",
-            "dev": true
-        },
-        "remove-trailing-separator": {
-            "version": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
-            "integrity": "sha1-YV67lq9VlVLUv0BXyENtSGq2PMQ=",
-            "dev": true
-        },
-        "repeat-element": {
-            "version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-            "dev": true
-        },
-        "repeat-string": {
-            "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-            "dev": true
-        },
-        "repeating": {
-            "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-            "dev": true,
-            "requires": {
-                "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
-            }
-        },
-        "replace-ext": {
-            "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-            "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-            "dev": true
-        },
-        "request": {
-            "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-            "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-            "requires": {
-                "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-                "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-                "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-                "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-                "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-                "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-                "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                "performance-now": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-                "qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-                "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-                "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-                "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
-            }
-        },
-        "request-progress": {
-            "version": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
-            "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-            "dev": true,
-            "requires": {
-                "throttleit": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz"
-            }
-        },
-        "requestretry": {
-            "version": "https://registry.npmjs.org/requestretry/-/requestretry-1.5.0.tgz",
-            "integrity": "sha1-7RV7ulNSbt6z7DKo5wSkmYvs5ic=",
-            "dev": true,
-            "requires": {
-                "fg-lodash": "https://registry.npmjs.org/fg-lodash/-/fg-lodash-0.0.2.tgz",
-                "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
-            }
-        },
-        "require-dir": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.2.tgz",
-            "integrity": "sha1-wdXHXp+//eny5rM+OD209ZS1pqk=",
-            "dev": true
-        },
-        "require-relative": {
-            "version": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-            "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
-            "dev": true
-        },
-        "resolve": {
-            "version": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-            "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-            "dev": true,
-            "requires": {
-                "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
-            }
-        },
-        "resolve-dir": {
-            "version": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-            "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-            "dev": true,
-            "requires": {
-                "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-                "global-modules": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
-            }
-        },
-        "resolve-url": {
-            "version": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-            "dev": true
-        },
-        "restore-cursor": {
-            "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-            "dev": true,
-            "requires": {
-                "onetime": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-                "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-            }
-        },
-        "revalidator": {
-            "version": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
-            "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
-            "dev": true
-        },
-        "rgb2hex": {
-            "version": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.0.tgz",
-            "integrity": "sha1-zNVfhgrgxcTqN1BLlY5ELY0SMls=",
-            "dev": true
-        },
-        "right-align": {
-            "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
-            }
-        },
-        "right-pad": {
-            "version": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
-            "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=",
-            "dev": true
-        },
-        "rimraf": {
-            "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-            "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-            "requires": {
-                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
-            }
-        },
-        "run-async": {
-            "version": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-            "dev": true,
-            "requires": {
-                "is-promise": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
-            }
-        },
-        "run-sequence": {
-            "version": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
-            "integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
-            "dev": true,
-            "requires": {
-                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz"
-            }
-        },
-        "rx": {
-            "version": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-            "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-            "dev": true
-        },
-        "rx-lite": {
-            "version": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-            "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-            "dev": true
-        },
-        "safe-buffer": {
-            "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-            "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
-        },
-        "saucelabs": {
-            "version": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.4.0.tgz",
-            "integrity": "sha1-uTSpr52ih0s/QKrh/N5QpEZvXzg=",
-            "dev": true,
-            "requires": {
-                "https-proxy-agent": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz"
-            }
-        },
-        "selenium-standalone": {
-            "version": "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-5.11.2.tgz",
-            "integrity": "sha1-ckzKpy+ybzcR4OIJieR4xBM9+EQ=",
-            "dev": true,
-            "requires": {
-                "async": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
-                "commander": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
-                "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-                "request": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-                "tar-stream": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
-                "urijs": "https://registry.npmjs.org/urijs/-/urijs-1.16.1.tgz",
-                "which": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
-                "yauzl": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
-                    "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA=",
-                    "dev": true
-                },
-                "caseless": {
-                    "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                    "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-                    "dev": true
-                },
-                "commander": {
-                    "version": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-                    "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
-                    "dev": true
-                },
-                "har-validator": {
-                    "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                    "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-                        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-                    },
-                    "dependencies": {
-                        "commander": {
-                            "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-                            "dev": true,
-                            "requires": {
-                                "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                            }
-                        }
-                    }
-                },
-                "lodash": {
-                    "version": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
-                    "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI=",
-                    "dev": true
-                },
-                "minimist": {
-                    "version": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
-                    "integrity": "sha1-zfIl6ImPhAolje1E/JF3Z3Cv3JM=",
-                    "dev": true
-                },
-                "mkdirp": {
-                    "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                    "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                            "dev": true
-                        }
-                    }
-                },
-                "qs": {
-                    "version": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-                    "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-                    "dev": true
-                },
-                "request": {
-                    "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-                    "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-                    "dev": true,
-                    "requires": {
-                        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                        "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-                        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-                        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                        "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-                        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                        "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-                        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                        "qs": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-                        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
-                    }
-                },
-                "tunnel-agent": {
-                    "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                    "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-                    "dev": true
-                },
-                "which": {
-                    "version": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
-                    "integrity": "sha1-nOUSRZlGFm4SwIPwjsBzOA/Iy7s=",
-                    "dev": true,
-                    "requires": {
-                        "is-absolute": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz"
-                    }
-                },
-                "yauzl": {
-                    "version": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
-                    "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
-                    "dev": true,
-                    "requires": {
-                        "buffer-crc32": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-                        "fd-slicer": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
-                    }
-                }
-            }
-        },
-        "semver": {
-            "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-            "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
-        },
-        "semver-regex": {
-            "version": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
-            "integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=",
-            "dev": true
-        },
-        "sequencify": {
-            "version": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-            "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
-            "dev": true
-        },
-        "set-blocking": {
-            "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-        },
-        "set-immediate-shim": {
-            "version": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-            "dev": true
-        },
-        "shelljs": {
-            "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
-            "integrity": "sha1-N5zM+1a5HIYB5HkzVutTgpJN6a0=",
-            "dev": true,
-            "requires": {
-                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-                "rechoir": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
-            }
-        },
-        "shellwords": {
-            "version": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
-            "integrity": "sha1-Zq/Ue2oSky2Qccv9mKUueFzQuhQ=",
-            "dev": true
-        },
-        "sigmund": {
-            "version": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-            "dev": true
-        },
-        "signal-exit": {
-            "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-        },
-        "simple-commit-message": {
-            "version": "https://registry.npmjs.org/simple-commit-message/-/simple-commit-message-2.2.1.tgz",
-            "integrity": "sha1-ZyzHNOpKiAq6KzgNH3sNg6/ZAbs=",
-            "dev": true,
-            "requires": {
-                "check-more-types": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.10.0.tgz",
-                "ggit": "https://registry.npmjs.org/ggit/-/ggit-1.12.0.tgz",
-                "hr": "https://registry.npmjs.org/hr/-/hr-0.1.3.tgz",
-                "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.1.tgz",
-                "inquirer-confirm": "https://registry.npmjs.org/inquirer-confirm/-/inquirer-confirm-0.2.2.tgz",
-                "lazy-ass": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-                "word-wrap": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.1.0.tgz"
-            },
-            "dependencies": {
-                "bluebird": {
-                    "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
-                    "integrity": "sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8=",
-                    "dev": true
-                },
-                "chdir-promise": {
-                    "version": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.2.1.tgz",
-                    "integrity": "sha1-x12STdMfas6u6rxDZZdh2lcSvEk=",
-                    "dev": true,
-                    "requires": {
-                        "check-more-types": "https://registry.npmjs.org/check-more-types/-/check-more-types-1.1.0.tgz",
-                        "check-types": "https://registry.npmjs.org/check-types/-/check-types-1.4.0.tgz",
-                        "lazy-ass": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-0.5.3.tgz",
-                        "q": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-                        "spots": "https://registry.npmjs.org/spots/-/spots-0.3.0.tgz"
-                    },
-                    "dependencies": {
-                        "check-more-types": {
-                            "version": "https://registry.npmjs.org/check-more-types/-/check-more-types-1.1.0.tgz",
-                            "integrity": "sha1-PQ42y/vpB7Pl7AoU9rJWCGRSwhY=",
-                            "dev": true
-                        },
-                        "lazy-ass": {
-                            "version": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-0.5.3.tgz",
-                            "integrity": "sha1-ST4dgBmLeY95tyQE6K9l8vAqAGU=",
-                            "dev": true
-                        },
-                        "q": {
-                            "version": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-                            "integrity": "sha1-Y1fikSBnAdmfGXq4TlforRlvKok=",
-                            "dev": true
-                        }
-                    }
-                },
-                "check-more-types": {
-                    "version": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.10.0.tgz",
-                    "integrity": "sha1-fPV2wgy4s40OfbKYH4u6RPjNF9M=",
-                    "dev": true
-                },
-                "cli-cursor": {
-                    "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-                    "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-                    "dev": true,
-                    "requires": {
-                        "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
-                    }
-                },
-                "cli-width": {
-                    "version": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
-                    "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
-                    "dev": true
-                },
-                "debug": {
-                    "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                    "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-                    "dev": true,
-                    "requires": {
-                        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                    }
-                },
-                "figures": {
-                    "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-                    "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-                    "dev": true,
-                    "requires": {
-                        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                    }
-                },
-                "ggit": {
-                    "version": "https://registry.npmjs.org/ggit/-/ggit-1.12.0.tgz",
-                    "integrity": "sha1-tPZbnfRLqnYl1QyMmuRVU/T+HC0=",
-                    "dev": true,
-                    "requires": {
-                        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
-                        "chdir-promise": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.2.1.tgz",
-                        "check-more-types": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-                        "cli-table": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-                        "colors": "1.1.2",
-                        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                        "d3-helpers": "https://registry.npmjs.org/d3-helpers/-/d3-helpers-0.3.0.tgz",
-                        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                        "lazy-ass": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
-                        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                        "moment": "https://registry.npmjs.org/moment/-/moment-2.17.0.tgz",
-                        "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                        "q": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
-                        "quote": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
-                        "ramda": "https://registry.npmjs.org/ramda/-/ramda-0.9.1.tgz"
-                    },
-                    "dependencies": {
-                        "check-more-types": {
-                            "version": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
-                            "integrity": "sha1-YiYmTTCxCVqhwKW4dO291dLQpm8=",
-                            "dev": true
-                        }
-                    }
-                },
-                "inquirer": {
-                    "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.1.tgz",
-                    "integrity": "sha1-YjtuDBAdL+no6O2QLmUeBRnRQ+U=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-                        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                        "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-                        "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
-                        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-                        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                        "readline2": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-                        "run-async": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-                        "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-                        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                    }
-                },
-                "lodash": {
-                    "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-                    "dev": true
-                },
-                "moment": {
-                    "version": "https://registry.npmjs.org/moment/-/moment-2.17.0.tgz",
-                    "integrity": "sha1-pMKS4CqsXd77Kabu0k9Rk43Tt08=",
-                    "dev": true
-                },
-                "ms": {
-                    "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                    "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-                    "dev": true
-                },
-                "onetime": {
-                    "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-                    "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-                    "dev": true
-                },
-                "q": {
-                    "version": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
-                    "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
-                    "dev": true,
-                    "requires": {
-                        "asap": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-                        "pop-iterate": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",
-                        "weak-map": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz"
-                    }
-                },
-                "restore-cursor": {
-                    "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                    "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-                    "dev": true,
-                    "requires": {
-                        "exit-hook": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-                        "onetime": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
-                    }
-                },
-                "run-async": {
-                    "version": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-                    "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-                    "dev": true,
-                    "requires": {
-                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-                    }
-                },
-                "semver": {
-                    "version": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-                    "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
-                    "dev": true
-                },
-                "spots": {
-                    "version": "https://registry.npmjs.org/spots/-/spots-0.3.0.tgz",
-                    "integrity": "sha1-tWkRTdMsUI4iC59rrB0IjN334NY=",
-                    "dev": true
-                },
-                "word-wrap": {
-                    "version": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.1.0.tgz",
-                    "integrity": "sha1-NWFT1h0QYQ1gB4XF1wEojgrnZKY=",
-                    "dev": true
-                }
-            }
-        },
-        "slash": {
-            "version": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-            "dev": true
-        },
-        "slug": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/slug/-/slug-0.9.1.tgz",
-            "integrity": "sha1-rwj2CKfBFRa2F3iqgA3OhMUYz9o=",
-            "requires": {
-                "unicode": "https://registry.npmjs.org/unicode/-/unicode-9.0.1.tgz"
-            }
-        },
-        "sntp": {
-            "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-            "requires": {
-                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-            }
-        },
-        "source-map": {
-            "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-            "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-            "dev": true
-        },
-        "source-map-resolve": {
-            "version": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-            "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
-            "dev": true,
-            "requires": {
-                "atob": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-                "resolve-url": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-                "source-map-url": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-                "urix": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
-            }
-        },
-        "source-map-support": {
-            "version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-            "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-            "dev": true,
-            "requires": {
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-            }
-        },
-        "source-map-url": {
-            "version": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-            "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
-            "dev": true
-        },
-        "sparkles": {
-            "version": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-            "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
-            "dev": true
-        },
-        "spawn-sync": {
-            "version": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-            "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-            "dev": true,
-            "requires": {
-                "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-                "os-shim": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
-            }
-        },
-        "spdx-correct": {
-            "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-            "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-            "dev": true,
-            "requires": {
-                "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-            }
-        },
-        "spdx-expression-parse": {
-            "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-            "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-            "dev": true
-        },
-        "spdx-license-ids": {
-            "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-            "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-            "dev": true
-        },
-        "split": {
-            "version": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
-            "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
-            "dev": true,
-            "requires": {
-                "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-            }
-        },
-        "split2": {
-            "version": "https://registry.npmjs.org/split2/-/split2-2.1.1.tgz",
-            "integrity": "sha1-eh9VHhdqkOzTNF9yRqDP4XXvT9A=",
-            "dev": true,
-            "requires": {
-                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-            }
-        },
-        "spots": {
-            "version": "https://registry.npmjs.org/spots/-/spots-0.4.0.tgz",
-            "integrity": "sha1-Ae7F78FDZp2dOiDj7si4y9mELfY=",
-            "dev": true
-        },
-        "sshpk": {
-            "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-            "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
-            "requires": {
-                "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-                "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-                "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
-            }
-        },
-        "stack-chain": {
-            "version": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-            "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=",
-            "dev": true
-        },
-        "stack-generator": {
-            "version": "https://registry.npmjs.org/stack-generator/-/stack-generator-1.1.0.tgz",
-            "integrity": "sha1-NvapIHUabBD0maE8Msu19RoLiyU=",
-            "dev": true,
-            "requires": {
-                "stackframe": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.3.tgz"
-            },
-            "dependencies": {
-                "stackframe": {
-                    "version": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.3.tgz",
-                    "integrity": "sha1-/mSrILFw5M5JBEsSbBGd+g5dx8w=",
-                    "dev": true
-                }
-            }
-        },
-        "stack-trace": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
-        },
-        "stackframe": {
-            "version": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
-            "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=",
-            "dev": true
-        },
-        "stacktrace-gps": {
-            "version": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-2.4.4.tgz",
-            "integrity": "sha1-acgn6dbW9Bz0ONfxleLjy/zyjEQ=",
-            "dev": true,
-            "requires": {
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                "stackframe": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz"
-            }
-        },
-        "stacktrace-js": {
-            "version": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-1.3.1.tgz",
-            "integrity": "sha1-Z8qyWJr1xBe5Yvc2mUAne7O2oYs=",
-            "dev": true,
-            "requires": {
-                "error-stack-parser": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
-                "stack-generator": "https://registry.npmjs.org/stack-generator/-/stack-generator-1.1.0.tgz",
-                "stacktrace-gps": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-2.4.4.tgz"
-            }
-        },
-        "stream-consume": {
-            "version": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
-            "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
-            "dev": true
-        },
-        "streamsearch": {
-            "version": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-            "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
-        },
-        "string-width": {
-            "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "requires": {
-                "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-            }
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
         },
         "string_decoder": {
-            "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-            "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
-            "requires": {
-                "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-            }
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "bump-regex": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/bump-regex/-/bump-regex-2.8.0.tgz",
+      "integrity": "sha512-prjTDXzGEbTvCgDVEAKvOGpAqZnz5EmzJNiYi2L72TjNy+T91w3SbPgofnAsLXZZBqZigv+kN4oF5oEIyr6LPw==",
+      "dev": true
+    },
+    "busboy": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
-        "stringstream": {
-            "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
         },
-        "strip-ansi": {
-            "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "requires": {
-                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-            }
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "cachedir": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-1.1.1.tgz",
+      "integrity": "sha1-4TYwdeogahJ2fZK7cRyKL3ahD2I=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true
+    },
+    "chai-as-promised": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-6.0.0.tgz",
+      "integrity": "sha1-GgKkM6byTa+sY7nJb6FoTbGqjaY=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "chdir-promise": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/chdir-promise/-/chdir-promise-0.4.1.tgz",
+      "integrity": "sha1-GIi7M3GWmcn7chOMB1VlA8SRPoU=",
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true
         },
-        "strip-bom": {
-            "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "dev": true,
-            "requires": {
-                "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-            }
+        "q": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+          "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
+          "dev": true
+        }
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "check-more-types": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
+      "dev": true
+    },
+    "cheerio": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
+      "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        }
+      }
+    },
+    "child-process-debug": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/child-process-debug/-/child-process-debug-0.0.7.tgz",
+      "integrity": "sha1-VOEfuBw7b5Spa2MfrKk+0a9/itA=",
+      "dev": true
+    },
+    "chimp": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/chimp/-/chimp-0.49.1.tgz",
+      "integrity": "sha1-2LLJPsTRIIbCxTeficxjwL2ZvJ4=",
+      "dev": true,
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
         },
-        "strip-bom-buf": {
-            "version": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
-            "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
-            "dev": true,
-            "requires": {
-                "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-            }
-        },
-        "strip-bom-stream": {
-            "version": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-3.0.0.tgz",
-            "integrity": "sha1-lWvMXYRDD2klapDtgjdlzYWOFZw=",
-            "dev": true,
-            "requires": {
-                "first-chunk-stream": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
-                "strip-bom-buf": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz"
-            },
-            "dependencies": {
-                "first-chunk-stream": {
-                    "version": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
-                    "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
+        "cucumber": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "dependencies": {
+            "camel-case": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "dependencies": {
+                "no-case": {
+                  "version": "2.3.1",
+                  "bundled": true,
+                  "dev": true,
+                  "dependencies": {
+                    "lower-case": {
+                      "version": "1.1.4",
+                      "bundled": true,
+                      "dev": true
                     }
-                }
-            }
-        },
-        "strip-indent": {
-            "version": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-            "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-            "dev": true,
-            "requires": {
-                "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-            }
-        },
-        "strip-json-comments": {
-            "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-        },
-        "supports-color": {
-            "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-            "dev": true
-        },
-        "tar": {
-            "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-            "requires": {
-                "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-                "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            }
-        },
-        "tar-pack": {
-            "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
-            "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
-            "requires": {
-                "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-                "fstream-ignore": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-                "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-                "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-                "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-                "uid-number": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-                    "requires": {
-                        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                    }
+                  }
                 },
-                "ms": {
-                    "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                    "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-                },
-                "once": {
-                    "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                    "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-                    "requires": {
-                        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-                    "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
-                    "requires": {
-                        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                },
-                "string_decoder": {
-                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                "upper-case": {
+                  "version": "1.1.3",
+                  "bundled": true,
+                  "dev": true
                 }
-            }
-        },
-        "tar-stream": {
-            "version": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
-            "integrity": "sha1-+8bG6DwaGdTLSMfZYXH8JI7/x78=",
-            "dev": true,
-            "requires": {
-                "bl": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-                "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              }
             },
-            "dependencies": {
-                "bl": {
-                    "version": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-                    "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
-                    }
+            "cli-table": {
+              "version": "0.3.1",
+              "bundled": true,
+              "dev": true,
+              "dependencies": {
+                "colors": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "dev": true
                 }
-            }
-        },
-        "tempfile": {
-            "version": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
-            "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
-            "dev": true,
-            "requires": {
-                "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-                "uuid": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
+              }
             },
-            "dependencies": {
-                "uuid": {
-                    "version": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-                    "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-                    "dev": true
+            "co": {
+              "version": "4.6.0",
+              "bundled": true,
+              "dev": true
+            },
+            "duration": {
+              "version": "0.2.0",
+              "bundled": true,
+              "dev": true,
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "es5-ext": {
+                  "version": "0.10.24",
+                  "bundled": true,
+                  "dev": true,
+                  "dependencies": {
+                    "es6-iterator": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "dependencies": {
+                        "d": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "es6-symbol": {
+                      "version": "3.1.1",
+                      "bundled": true,
+                      "dev": true,
+                      "dependencies": {
+                        "d": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
                 }
+              }
+            },
+            "figures": {
+              "version": "1.7.0",
+              "bundled": true,
+              "dev": true,
+              "dependencies": {
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "dev": true
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "gherkin": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-generator": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash": {
+              "version": "4.17.4",
+              "bundled": true,
+              "dev": true
+            },
+            "meteor-promise": {
+              "version": "0.8.5",
+              "bundled": true,
+              "dev": true
+            },
+            "stack-chain": {
+              "version": "1.3.7",
+              "bundled": true,
+              "dev": true
+            },
+            "stacktrace-js": {
+              "version": "1.3.1",
+              "bundled": true,
+              "dev": true,
+              "dependencies": {
+                "error-stack-parser": {
+                  "version": "1.3.6",
+                  "bundled": true,
+                  "dev": true,
+                  "dependencies": {
+                    "stackframe": {
+                      "version": "0.3.1",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "stack-generator": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "dependencies": {
+                    "stackframe": {
+                      "version": "1.0.3",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "stacktrace-gps": {
+                  "version": "2.4.4",
+                  "bundled": true,
+                  "dev": true,
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.5.6",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "stackframe": {
+                      "version": "0.3.1",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
             }
+          }
         },
-        "text-extensions": {
-            "version": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.4.0.tgz",
-            "integrity": "sha1-w4XS6Ah5/m75eJPhcJ2I2UU3Juk=",
-            "dev": true
+        "glob": {
+          "version": "github:lucetius/node-glob#51c7ca6e69bfbd17db5f1ea710e3f2a7a457d9ce",
+          "dev": true
         },
-        "throttleit": {
-            "version": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-            "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
-            "dev": true
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         },
-        "through": {
-            "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-            "dev": true
-        },
-        "through2": {
-            "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-        },
-        "tildify": {
-            "version": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-            "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-            "dev": true,
-            "requires": {
-                "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-            }
-        },
-        "time-stamp": {
-            "version": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
-            "integrity": "sha1-n0vSNVnJNllm8zAtu6KwfGuZsVE=",
-            "dev": true
-        },
-        "tmp": {
-            "version": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-            "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
-            "dev": true,
-            "requires": {
-                "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-            }
-        },
-        "to-fast-properties": {
-            "version": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-            "dev": true
-        },
-        "topo": {
-            "version": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-            "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-            "requires": {
-                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-            }
-        },
-        "tough-cookie": {
-            "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-            "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-            "requires": {
-                "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-            }
-        },
-        "trim-newlines": {
-            "version": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-            "dev": true
-        },
-        "trim-off-newlines": {
-            "version": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-            "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-            "dev": true
-        },
-        "trim-right": {
-            "version": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-            "dev": true
-        },
-        "tunnel-agent": {
-            "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "requires": {
-                "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-            }
-        },
-        "tweetnacl": {
-            "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "optional": true
-        },
-        "type-detect": {
-            "version": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-            "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
-            "dev": true
-        },
-        "typedarray": {
-            "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-            "dev": true
-        },
-        "uglify-js": {
-            "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
-            "integrity": "sha1-1Uk0d4qNoUkD+imjJvskwKtRoaA=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
-            }
-        },
-        "uglify-to-browserify": {
-            "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-            "dev": true,
-            "optional": true
-        },
-        "uid-number": {
-            "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-            "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
-        },
-        "unc-path-regex": {
-            "version": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-            "dev": true
+        "once": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.0.tgz",
+          "integrity": "sha1-FRr4a/wfCMS58H0GqyUP/L61ZYE=",
+          "dev": true
         },
         "underscore": {
-            "version": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-            "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "dev": true
+        }
+      }
+    },
+    "chokidar": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+      "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
+      "dev": true
+    },
+    "chromedriver": {
+      "version": "2.33.2",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.33.2.tgz",
+      "integrity": "sha512-etnQeM8Mqiys50ZB4IiuNqeB1WS2/EKFhVXwkPQ1qjzKMMAJUyrLjaRUcoZoHrbjGscnhBrWkRR+p3zcTGMhDg==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true
+    },
+    "cli-table": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+      "dev": true,
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        }
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "clone": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+      "dev": true
+    },
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true
+    },
+    "clone-stats": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+      "dev": true
+    },
+    "cloneable-readable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+      "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+    },
+    "commander": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+    },
+    "commitizen": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-2.9.6.tgz",
+      "integrity": "sha1-wNAFNe8mTaf2Nzft/aQiiYP6IpE=",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
         },
-        "underscore.deep": {
-            "version": "https://registry.npmjs.org/underscore.deep/-/underscore.deep-0.5.1.tgz",
-            "integrity": "sha1-ByZx9I1oc1w0Ij/P72PmnlJ2zCs="
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true
         },
-        "underscore.string": {
-            "version": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-            "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
-            "dev": true
+        "cz-conventional-changelog": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-1.2.0.tgz",
+          "integrity": "sha1-K8oElkyJGbI/P9aonvXmAIsxs/g=",
+          "dev": true
         },
-        "unicode": {
-            "version": "https://registry.npmjs.org/unicode/-/unicode-9.0.1.tgz",
-            "integrity": "sha1-EEcGJyxkZMV0gBvhsIb3JFzyUVg="
+        "external-editor": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+          "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+          "dev": true
         },
-        "unique-stream": {
-            "version": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-            "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
-            "dev": true
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true
         },
-        "upper-case": {
-            "version": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-            "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
-            "dev": true
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true
         },
-        "uri-js": {
-            "version": "https://registry.npmjs.org/uri-js/-/uri-js-2.1.1.tgz",
-            "integrity": "sha1-6z+FBfRolpv5LLec6M6qwu1mdmE="
+        "inquirer": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+          "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
+          "dev": true
         },
-        "urijs": {
-            "version": "https://registry.npmjs.org/urijs/-/urijs-1.16.1.tgz",
-            "integrity": "sha1-hZrTGJD1+VKHJ76J8ZMslPtHMeI=",
-            "dev": true
+        "lodash": {
+          "version": "4.17.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
+          "integrity": "sha1-NKMFW6vgTOQkZ7YH1wAHLH/2v0I=",
+          "dev": true
         },
-        "urix": {
-            "version": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-            "dev": true
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         },
-        "url": {
-            "version": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-            "dev": true,
-            "requires": {
-                "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-                "querystring": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
-            },
-            "dependencies": {
-                "punycode": {
-                    "version": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-                    "dev": true
-                }
-            }
+        "mute-stream": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+          "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
+          "dev": true
         },
-        "user-home": {
-            "version": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-            "dev": true
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
         },
-        "util-deprecate": {
-            "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true
         },
-        "utile": {
-            "version": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
-            "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
-            "dev": true,
-            "requires": {
-                "async": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                "deep-equal": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-                "i": "https://registry.npmjs.org/i/-/i-0.3.5.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "ncp": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
-                "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-                    "dev": true
-                }
-            }
+        "tmp": {
+          "version": "0.0.29",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+          "dev": true
+        }
+      }
+    },
+    "compare-func": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
+      "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+      "dev": true
+    },
+    "compress-commons": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "conventional-changelog": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.7.tgz",
+      "integrity": "sha1-kVGmKx2O2y2CcR2r9bfPcQQfgrE=",
+      "dev": true
+    },
+    "conventional-changelog-angular": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.5.2.tgz",
+      "integrity": "sha1-Kzj2Zf6cWSCvGi+C9Uf0ur5t5Xw=",
+      "dev": true
+    },
+    "conventional-changelog-atom": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.2.tgz",
+      "integrity": "sha1-Ella1SZ6aTfDTPkAKBscZRmKTGM=",
+      "dev": true
+    },
+    "conventional-changelog-cli": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.5.tgz",
+      "integrity": "sha1-RsUUliFrdAZYiIPe+m+sWJ6bsx4=",
+      "dev": true
+    },
+    "conventional-changelog-codemirror": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.2.1.tgz",
+      "integrity": "sha1-KZpPcUe681DmyBWPxUlUopHFzAk=",
+      "dev": true
+    },
+    "conventional-changelog-core": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.9.3.tgz",
+      "integrity": "sha1-KJn+d5OJoynw7EsnRsNt3vuY2i0=",
+      "dev": true
+    },
+    "conventional-changelog-ember": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.9.tgz",
+      "integrity": "sha1-jsc8wFTjqwZGZ/sf61L+jvGxZDg=",
+      "dev": true
+    },
+    "conventional-changelog-eslint": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.2.1.tgz",
+      "integrity": "sha1-LCoRvrIW+AZJunKDQYApO2h8BmI=",
+      "dev": true
+    },
+    "conventional-changelog-express": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.2.1.tgz",
+      "integrity": "sha1-g42eHmyQmXA7FQucGaoteBdCvWw=",
+      "dev": true
+    },
+    "conventional-changelog-jquery": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
+      "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
+      "dev": true
+    },
+    "conventional-changelog-jscs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
+      "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
+      "dev": true
+    },
+    "conventional-changelog-jshint": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.2.1.tgz",
+      "integrity": "sha1-hhObs6yZiZ8rF36WF+CbN9mbzzo=",
+      "dev": true
+    },
+    "conventional-changelog-writer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-2.0.2.tgz",
+      "integrity": "sha1-tYV97RsAHa+aeLnNQJJvRcE0lJs=",
+      "dev": true
+    },
+    "conventional-commit-message": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-commit-message/-/conventional-commit-message-1.1.0.tgz",
+      "integrity": "sha1-7OjGYaFo6YNpLh1aFIday1lRD2o=",
+      "dev": true,
+      "dependencies": {
+        "check-more-types": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.3.0.tgz",
+          "integrity": "sha1-uDl8adySo+ZF8YkywEWwnHRBnsQ=",
+          "dev": true
         },
-        "uuid": {
-            "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-            "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+        "cz-conventional-changelog": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-1.1.5.tgz",
+          "integrity": "sha1-Ck0VUMTi+2o67Y9s2FjCF2DhGbg=",
+          "dev": true
         },
-        "v8flags": {
-            "version": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-            "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-            "dev": true,
-            "requires": {
-                "user-home": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-            }
-        },
-        "validate-commit-msg": {
-            "version": "https://registry.npmjs.org/validate-commit-msg/-/validate-commit-msg-2.11.1.tgz",
-            "integrity": "sha1-yPhmQ8oDsm2htPPjfX9uZZ+8NMo=",
-            "dev": true,
-            "requires": {
-                "conventional-commit-types": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.1.0.tgz",
-                "findup": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
-                "semver-regex": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz"
-            }
-        },
-        "validate-npm-package-license": {
-            "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-            "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-            "dev": true,
-            "requires": {
-                "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
-            }
-        },
-        "validator": {
-            "version": "https://registry.npmjs.org/validator/-/validator-7.0.0.tgz",
-            "integrity": "sha1-x03rgGNRL6w1VHk45vCxUEooL9I=",
-            "dev": true
-        },
-        "verror": {
-            "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-            "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-            "requires": {
-                "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-            }
-        },
-        "vinyl": {
-            "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-            "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-            "dev": true,
-            "requires": {
-                "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-                "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-                "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-            }
-        },
-        "vinyl-fs": {
-            "version": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-            "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
-            "dev": true,
-            "requires": {
-                "defaults": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-                "glob-stream": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-                "glob-watcher": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-                "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-                    "dev": true
-                },
-                "graceful-fs": {
-                    "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-                    "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-                    "dev": true,
-                    "requires": {
-                        "natives": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
-                    }
-                },
-                "isarray": {
-                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                },
-                "string_decoder": {
-                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "strip-bom": {
-                    "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-                    "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-                    "dev": true,
-                    "requires": {
-                        "first-chunk-stream": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-                        "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-                    }
-                },
-                "through2": {
-                    "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                    }
-                },
-                "vinyl": {
-                    "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                        "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-                    }
-                }
-            }
-        },
-        "walkdir": {
-            "version": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
-            "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
-            "dev": true
-        },
-        "wdio-dot-reporter": {
-            "version": "https://registry.npmjs.org/wdio-dot-reporter/-/wdio-dot-reporter-0.0.8.tgz",
-            "integrity": "sha1-NhlVdtoNmYIQxxlIy7ZfW/Eb/GU=",
-            "dev": true
-        },
-        "wdio-sync": {
-            "version": "https://registry.npmjs.org/wdio-sync/-/wdio-sync-0.6.14.tgz",
-            "integrity": "sha1-odzVkHuh0EFUquYXbGItkQw8qbM=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "fibers": "https://registry.npmjs.org/fibers/-/fibers-1.0.15.tgz",
-                "object.assign": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz"
-            }
-        },
-        "weak-map": {
-            "version": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz",
-            "integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes=",
-            "dev": true
-        },
-        "webdriverio": {
-            "version": "https://registry.npmjs.org/webdriverio/-/webdriverio-4.8.0.tgz",
-            "integrity": "sha1-1Skpt0kID4mWf24WFAUcvIFy0TI=",
-            "dev": true,
-            "requires": {
-                "archiver": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "css-parse": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
-                "css-value": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
-                "deepmerge": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.3.2.tgz",
-                "ejs": "https://registry.npmjs.org/ejs/-/ejs-2.5.6.tgz",
-                "gaze": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
-                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
-                "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "npm-install-package": "https://registry.npmjs.org/npm-install-package/-/npm-install-package-2.1.0.tgz",
-                "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-                "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-                "rgb2hex": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.0.tgz",
-                "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                "url": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-                "validator": "https://registry.npmjs.org/validator/-/validator-7.0.0.tgz",
-                "wdio-dot-reporter": "https://registry.npmjs.org/wdio-dot-reporter/-/wdio-dot-reporter-0.0.8.tgz",
-                "wgxpath": "https://registry.npmjs.org/wgxpath/-/wgxpath-1.0.0.tgz"
-            },
-            "dependencies": {
-                "supports-color": {
-                    "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                    }
-                }
-            }
-        },
-        "websocket-driver": {
-            "version": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-            "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
-            "dev": true,
-            "requires": {
-                "websocket-extensions": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
-            }
-        },
-        "websocket-extensions": {
-            "version": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
-            "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec=",
-            "dev": true
-        },
-        "wgxpath": {
-            "version": "https://registry.npmjs.org/wgxpath/-/wgxpath-1.0.0.tgz",
-            "integrity": "sha1-7vikudVYzEla06mit1FZfs2a9pA=",
-            "dev": true
-        },
-        "which": {
-            "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-            "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-            "requires": {
-                "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-            }
-        },
-        "wide-align": {
-            "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-            "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
-            "requires": {
-                "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-            }
-        },
-        "window-size": {
-            "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-            "dev": true,
-            "optional": true
-        },
-        "winston": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
-            "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
-            "requires": {
-                "async": "https://registry.npmjs.org/async/-/async-2.4.0.tgz",
-                "colors": "1.0.3",
-                "cycle": "1.0.3",
-                "eyes": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-                "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                "stack-trace": "0.0.10"
-            },
-            "dependencies": {
-                "colors": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-                    "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-                }
-            }
+        "lazy-ass": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.3.0.tgz",
+          "integrity": "sha1-fQ0U7vPslwLG8wxg6oHxqNP5APs=",
+          "dev": true
         },
         "word-wrap": {
-            "version": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.2.tgz",
-            "integrity": "sha1-j6eMO9o+MTjHeX+rzq5wmWiBS0E=",
-            "dev": true
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.1.0.tgz",
+          "integrity": "sha1-NWFT1h0QYQ1gB4XF1wEojgrnZKY=",
+          "dev": true
+        }
+      }
+    },
+    "conventional-commit-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.2.0.tgz",
+      "integrity": "sha1-XblXOdbCEqy+e29lahG5QLqmiUY=",
+      "dev": true
+    },
+    "conventional-commits-filter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.0.tgz",
+      "integrity": "sha1-H8Ka8wte2rdvVOIpxBGwxmPQ+es=",
+      "dev": true
+    },
+    "conventional-commits-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.0.1.tgz",
+      "integrity": "sha1-HxXOa4RPfKQUlcgZDAgzwwuLFpM=",
+      "dev": true
+    },
+    "conventional-github-releaser": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/conventional-github-releaser/-/conventional-github-releaser-1.1.13.tgz",
+      "integrity": "sha1-C+ezp8eGfoiL5SZHWlkP9ZMDUXw=",
+      "dev": true
+    },
+    "conventional-recommended-bump": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.0.3.tgz",
+      "integrity": "sha1-RytpsbjwnFxO1A/iikHmPMBL1zY=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "country-language": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/country-language/-/country-language-0.1.7.tgz",
+      "integrity": "sha1-eHD0uhJduaYHHxlze9nvk0OuNds="
+    },
+    "crc": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+      "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ=",
+      "dev": true
+    },
+    "crc32-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE="
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw=="
         },
-        "wordwrap": {
-            "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-            "dev": true
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+        }
+      }
+    },
+    "css": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+      "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
+      "dev": true,
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true
+        }
+      }
+    },
+    "css-parse": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
+      "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
+      "dev": true
+    },
+    "css-select": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
+      "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA="
+    },
+    "css-value": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
+      "integrity": "sha1-Xv1sLupeof1rasV+wEJ7GEUkJOo=",
+      "dev": true
+    },
+    "css-what": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
+      "integrity": "sha1-18wt9FGAZm+Z0rFEYmOUaeAPc2w="
+    },
+    "ctype": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    },
+    "cz-conventional-changelog": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-2.1.0.tgz",
+      "integrity": "sha1-L0vHOQ4yROTfKT5ro1Hkx0Cnx2Q=",
+      "dev": true
+    },
+    "d3-helpers": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/d3-helpers/-/d3-helpers-0.3.0.tgz",
+      "integrity": "sha1-SzHc5KISGnczY4RXTYk/vtX7KT0=",
+      "dev": true
+    },
+    "dargs": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
+      "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
+      "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA="
+    },
+    "dateformat": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+      "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+      "dev": true
+    },
+    "ddp-ejson": {
+      "version": "0.8.1-3",
+      "resolved": "https://registry.npmjs.org/ddp-ejson/-/ddp-ejson-0.8.1-3.tgz",
+      "integrity": "sha1-6dZ0Zqt4m9dOfZcHSjbiQGkO7sI=",
+      "dev": true
+    },
+    "ddp-underscore-patched": {
+      "version": "0.8.1-2",
+      "resolved": "https://registry.npmjs.org/ddp-underscore-patched/-/ddp-underscore-patched-0.8.1-2.tgz",
+      "integrity": "sha1-ZaQU6fIuxagqoWOG40NmtI/Ozx0=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "dedent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",
+      "integrity": "sha1-Dm2o8M5Sg471zsXI+TlrDBtko8s=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "deep-equal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+    },
+    "deeper": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz",
+      "integrity": "sha1-vFZOX3MXT98gHgiwADDooU2nQ2g="
+    },
+    "deepmerge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.0.1.tgz",
+      "integrity": "sha512-VIPwiMJqJ13ZQfaCsIFnp5Me9tnjURiaIFxfz7EH0Ci0dTSQpZtSLrqOicXqEd/z2r+z+Klk9GzmnRsgpgbOsQ==",
+      "dev": true
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true
+    },
+    "del": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "deprecated": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+      "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
+      "dev": true
+    },
+    "detect-file": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+      "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true
+    },
+    "dicer": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg="
+    },
+    "domutils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+      "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8="
+    },
+    "dot-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+      "dev": true
+    },
+    "duplexer2": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
+      "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE="
+    },
+    "ejs": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
+      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
+      "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "dev": true
+    },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true
+    },
+    "es6-promise": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
+      "integrity": "sha1-eILzCt3lskDM+n99eMVIMwlRrkI=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "eventemitter2": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-4.1.2.tgz",
+      "integrity": "sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU="
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true
+    },
+    "expand-tilde": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extend-shallow": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+      "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        }
+      }
+    },
+    "external-editor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "dev": true
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true
+    },
+    "extract-zip": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
+      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
+      "integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8="
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    },
+    "fancy-log": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "faye-websocket": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz",
+      "integrity": "sha1-iFk0x57/sECVSeDAo4Ae0XpAza0=",
+      "dev": true
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true
+    },
+    "fg-lodash": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/fg-lodash/-/fg-lodash-0.0.2.tgz",
+      "integrity": "sha1-mINSU39CfaavIiEpu2OsyknmL6M=",
+      "dev": true,
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        }
+      }
+    },
+    "fibers": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/fibers/-/fibers-1.0.15.tgz",
+      "integrity": "sha1-IvA5yPGLhWGQ+75N7PBWFUwerpw=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "dev": true
+    },
+    "find-index": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
+      "dev": true
+    },
+    "find-node-modules": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-1.0.4.tgz",
+      "integrity": "sha1-tt6zzMtpnIcDdne87eLF9YYrJVA=",
+      "dev": true
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
+    },
+    "find-root": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.0.0.tgz",
+      "integrity": "sha1-li/yEaqyXGUg/u641ih/j26VgHo=",
+      "dev": true
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true
+    },
+    "findup": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
+      "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
+      "dev": true,
+      "dependencies": {
+        "colors": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
+          "dev": true
+        }
+      }
+    },
+    "findup-sync": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz",
+      "integrity": "sha1-qBF9D3MST1pFRoOVef5S1xKfteU=",
+      "dev": true
+    },
+    "fined": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
+      "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
+      "dev": true,
+      "dependencies": {
+        "expand-tilde": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+          "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+          "dev": true
+        }
+      }
+    },
+    "first-chunk-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+      "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+      "dev": true
+    },
+    "flagged-respawn": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
+      "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU=",
+      "dev": true
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8="
+    },
+    "freeport": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/freeport/-/freeport-1.0.5.tgz",
+      "integrity": "sha1-JV6KuEFwwzuoXZkOghrl9KGpvF0=",
+      "dev": true
+    },
+    "fs-exists-sync": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+      "dev": true
+    },
+    "fs-extra": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "wrappy": {
-            "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE="
+    },
+    "fstream-ignore": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c="
+    },
+    "gaze": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+      "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA="
+    },
+    "get-pkg-repo": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
+      "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo="
+    },
+    "ggit": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ggit/-/ggit-2.4.0.tgz",
+      "integrity": "sha1-uZ2YHz7eKjqKjku/9Xi8J31ABYg=",
+      "dev": true,
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
         },
-        "xolvio-ddp": {
-            "version": "https://registry.npmjs.org/xolvio-ddp/-/xolvio-ddp-0.12.3.tgz",
-            "integrity": "sha1-NqarlhKyQLWg0cCoNJCK8XwLjwI=",
-            "dev": true,
-            "requires": {
-                "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-                "ddp-ejson": "https://registry.npmjs.org/ddp-ejson/-/ddp-ejson-0.8.1-3.tgz",
-                "ddp-underscore-patched": "https://registry.npmjs.org/ddp-underscore-patched/-/ddp-underscore-patched-0.8.1-2.tgz",
-                "faye-websocket": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz",
-                "request": "https://registry.npmjs.org/request/-/request-2.53.0.tgz"
-            },
-            "dependencies": {
-                "asn1": {
-                    "version": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                    "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
-                    "dev": true
-                },
-                "assert-plus": {
-                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                    "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
-                    "dev": true
-                },
-                "async": {
-                    "version": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-                    "dev": true
-                },
-                "aws-sign2": {
-                    "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-                    "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
-                    "dev": true
-                },
-                "bluebird": {
-                    "version": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-                    "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
-                    "dev": true
-                },
-                "caseless": {
-                    "version": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-                    "integrity": "sha1-t7Zc5r8UE4hlOc/VM/CzDv+pz4g=",
-                    "dev": true
-                },
-                "combined-stream": {
-                    "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                    "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-                    "dev": true,
-                    "requires": {
-                        "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                    }
-                },
-                "delayed-stream": {
-                    "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                    "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
-                    "dev": true
-                },
-                "forever-agent": {
-                    "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-                    "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA=",
-                    "dev": true
-                },
-                "form-data": {
-                    "version": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-                    "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
-                    "dev": true,
-                    "requires": {
-                        "async": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
-                    }
-                },
-                "hawk": {
-                    "version": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-                    "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                        "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                    }
-                },
-                "http-signature": {
-                    "version": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-                    "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
-                    "dev": true,
-                    "requires": {
-                        "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                        "ctype": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                    }
-                },
-                "mime-db": {
-                    "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-                    "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
-                    "dev": true
-                },
-                "mime-types": {
-                    "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-                    "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
-                    "dev": true,
-                    "requires": {
-                        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-                    }
-                },
-                "node-uuid": {
-                    "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-                    "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-                    "dev": true
-                },
-                "oauth-sign": {
-                    "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-                    "integrity": "sha1-fb6uRPbKRU4fFoRR1jB0ZzWBPOM=",
-                    "dev": true
-                },
-                "qs": {
-                    "version": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-                    "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
-                    "dev": true
-                },
-                "request": {
-                    "version": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
-                    "integrity": "sha1-GAo66St7Y5gC5PlUXdj83rcddgw=",
-                    "dev": true,
-                    "requires": {
-                        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-                        "bl": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-                        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-                        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-                        "form-data": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-                        "hawk": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-                        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-                        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-                        "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-                        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-                        "qs": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-                        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
-                    }
-                },
-                "tunnel-agent": {
-                    "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                    "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-                    "dev": true
-                }
-            }
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true
         },
-        "xolvio-fiber-utils": {
-            "version": "https://registry.npmjs.org/xolvio-fiber-utils/-/xolvio-fiber-utils-2.0.3.tgz",
-            "integrity": "sha1-vsjXDHQGGjFjFbun0w0lyz6C3FA=",
-            "dev": true,
-            "requires": {
-                "fibers": "https://registry.npmjs.org/fibers/-/fibers-1.0.15.tgz",
-                "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                }
-            }
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true
         },
-        "xolvio-jasmine-expect": {
-            "version": "https://registry.npmjs.org/xolvio-jasmine-expect/-/xolvio-jasmine-expect-1.1.0.tgz",
-            "integrity": "sha1-vCud1ghCMR8EV59agtzqaisxnH0=",
-            "dev": true,
-            "requires": {
-                "jasmine-core": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.2.tgz"
-            }
+        "moment": {
+          "version": "2.19.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz",
+          "integrity": "sha1-VtoaLRy/AdOLfhr8McELz6GSkWc=",
+          "dev": true
         },
-        "xolvio-sync-webdriverio": {
-            "version": "https://registry.npmjs.org/xolvio-sync-webdriverio/-/xolvio-sync-webdriverio-9.0.1.tgz",
-            "integrity": "sha1-WRri2MiqynQiZJWfzM+QtPndUWA=",
-            "dev": true,
-            "requires": {
-                "fibers": "https://registry.npmjs.org/fibers/-/fibers-1.0.15.tgz",
-                "meteor-promise": "https://registry.npmjs.org/meteor-promise/-/meteor-promise-0.8.4.tgz",
-                "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                "wdio-sync": "https://registry.npmjs.org/wdio-sync/-/wdio-sync-0.6.14.tgz",
-                "webdriverio": "https://registry.npmjs.org/webdriverio/-/webdriverio-4.8.0.tgz",
-                "xolvio-fiber-utils": "https://registry.npmjs.org/xolvio-fiber-utils/-/xolvio-fiber-utils-2.0.3.tgz"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                }
+        "pluralize": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+          "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+          "dev": true
+        },
+        "q": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
+          "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
+          "dev": true
+        }
+      }
+    },
+    "git-raw-commits": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.0.tgz",
+      "integrity": "sha1-C8hZbpDV/+c29/VUa9LRL3OrqsY=",
+      "dev": true
+    },
+    "git-remote-origin-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+      "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+      "dev": true,
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "git-semver-tags": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.3.tgz",
+      "integrity": "sha1-GItFOIK/nXojr9Mbq6U32rc4jV0=",
+      "dev": true
+    },
+    "gitconfiglocal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+      "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+      "dev": true
+    },
+    "github": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
+      "integrity": "sha1-JPp/DhP6EblGr5ETTFGYKpHOU4s=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true
+    },
+    "glob-stream": {
+      "version": "3.1.18",
+      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+      "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "dev": true
+        }
+      }
+    },
+    "glob-watcher": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+      "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+      "dev": true,
+      "dependencies": {
+        "gaze": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+          "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+          "dev": true
+        },
+        "globule": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+          "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+          "dev": true
+        },
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "dev": true
+        }
+      }
+    },
+    "glob2base": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+      "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
+      "dev": true
+    },
+    "global-modules": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+      "dev": true
+    },
+    "global-prefix": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+      "dev": true
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+      "dev": true,
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "globule": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+      "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+      "dev": true
+    },
+    "glogg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+      "dev": true
+    },
+    "gm": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/gm/-/gm-1.23.0.tgz",
+      "integrity": "sha1-gKL+nL8TFRUCSEZERlhGEmn1JmE=",
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo="
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true
+    },
+    "gulp": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+      "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+          "dev": true
+        }
+      }
+    },
+    "gulp-bump": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/gulp-bump/-/gulp-bump-2.8.0.tgz",
+      "integrity": "sha512-syvQLax2xQo1EDFJxanUqX1rv+YkVB4/cx/THN+uInmSjMGezT1/6WYLdXqkBAMQUw2KlyB2melz0DzrHdwkLA==",
+      "dev": true
+    },
+    "gulp-conventional-changelog": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/gulp-conventional-changelog/-/gulp-conventional-changelog-1.1.7.tgz",
+      "integrity": "sha1-Azf2hLSeKTWOYj4W6UtJ8FotK/E=",
+      "dev": true
+    },
+    "gulp-git": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/gulp-git/-/gulp-git-2.4.2.tgz",
+      "integrity": "sha512-YgFW2PmtGSHkUYFql75ByRqFjiEDvOk7jxVkkqH0OSDKc3icxD8GDBR1kbr2zG7oNaIynk2NcKVSypgPHl7ibQ==",
+      "dev": true,
+      "dependencies": {
+        "clone": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+          "dev": true
+        },
+        "clone-stats": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+          "dev": true
+        },
+        "replace-ext": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+          "dev": true
+        },
+        "vinyl": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+          "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+          "dev": true
+        }
+      }
+    },
+    "gulp-help": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/gulp-help/-/gulp-help-1.6.1.tgz",
+      "integrity": "sha1-Jh2xhuGDl/7z9qLCLpwxW/qIrgw=",
+      "dev": true,
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+          "dev": true
+        }
+      }
+    },
+    "gulp-load-plugins": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/gulp-load-plugins/-/gulp-load-plugins-1.5.0.tgz",
+      "integrity": "sha1-TEGffldk2aDjMGG6uWGPgbc9QXE=",
+      "dev": true
+    },
+    "gulp-notify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-notify/-/gulp-notify-3.0.0.tgz",
+      "integrity": "sha1-oEuK+azb5OY8hFZ4zgw9MGlMWaM=",
+      "dev": true
+    },
+    "gulp-plumber": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.1.0.tgz",
+      "integrity": "sha1-8SF2wtBCL2AwbCQv/2oBo5T6ugk=",
+      "dev": true
+    },
+    "gulp-tag-version": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gulp-tag-version/-/gulp-tag-version-1.3.0.tgz",
+      "integrity": "sha1-hEjIfu0YZtuObLWYvEGb4t98R9s=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+          "dev": true
+        },
+        "gulp-git": {
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/gulp-git/-/gulp-git-0.3.6.tgz",
+          "integrity": "sha1-d+w9oiklwkbt15bKENQWOWXYFAo=",
+          "dev": true
+        },
+        "gulp-util": {
+          "version": "2.2.20",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+          "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
+          "dev": true,
+          "dependencies": {
+            "through2": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
+              "dev": true
             }
+          }
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "lodash._reinterpolate": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+          "integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI=",
+          "dev": true
+        },
+        "lodash.escape": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+          "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
+          "dev": true
+        },
+        "lodash.keys": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+          "dev": true
+        },
+        "lodash.template": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+          "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
+          "dev": true
+        },
+        "lodash.templatesettings": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+          "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
+          "dev": true
+        },
+        "map-stream": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+          "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+          "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784=",
+          "dev": true
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+          "dev": true,
+          "dependencies": {
+            "xtend": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+              "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+              "dev": true
+            }
+          }
+        },
+        "vinyl": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+          "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
+          "dev": true
         },
         "xtend": {
-            "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
+          "dev": true
+        }
+      }
+    },
+    "gulp-util": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+      "dev": true,
+      "dependencies": {
+        "dateformat": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+          "dev": true
         },
-        "yallist": {
-            "version": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        "lodash.template": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+          "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+          "dev": true
         },
-        "yargs": {
-            "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-            "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                    "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-                    "dev": true,
-                    "optional": true
-                }
+        "lodash.templatesettings": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+          "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+          "dev": true
+        }
+      }
+    },
+    "gulplog": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "dev": true,
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true
+        }
+      }
+    },
+    "hapi": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/hapi/-/hapi-8.8.0.tgz",
+      "integrity": "sha1-h+N6Bum0meiXkOLcERqpZotuYX8=",
+      "dev": true,
+      "dependencies": {
+        "accept": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz",
+          "integrity": "sha1-g++IOWi4WkDFARYEKCoiD/AeYq0=",
+          "dev": true
+        },
+        "ammo": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz",
+          "integrity": "sha1-4FlIG/aAhzj66G1GT3L6DBLWeoU=",
+          "dev": true
+        },
+        "boom": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
+          "integrity": "sha1-2tYo2Jf3/S4yzIIZfxMweXHPg1Q=",
+          "dev": true
+        },
+        "call": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/call/-/call-2.0.1.tgz",
+          "integrity": "sha1-SbQnCZQ96JoyJYqpEbWHUeI3eg4=",
+          "dev": true
+        },
+        "catbox": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/catbox/-/catbox-4.3.0.tgz",
+          "integrity": "sha1-IiN3vWfxKRrA4l0AAC0GWp3385o=",
+          "dev": true
+        },
+        "catbox-memory": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz",
+          "integrity": "sha1-QqUvgLye+nJmAeltQBYDNhJIGig=",
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+          "integrity": "sha1-CeoXdbnhx95+YKmdQqtvCM4aEoU=",
+          "dev": true
+        },
+        "h2o2": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.1.tgz",
+          "integrity": "sha1-eg4rztHZcXjsVs48ykjgxW3un40=",
+          "dev": true
+        },
+        "heavy": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz",
+          "integrity": "sha1-/QEIdiExYy+IVIontVQSws9SKwA=",
+          "dev": true
+        },
+        "hoek": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
+          "integrity": "sha1-gSEWkfUqWoNa5J7b8eickANHaqQ=",
+          "dev": true
+        },
+        "inert": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/inert/-/inert-2.1.5.tgz",
+          "integrity": "sha1-eybZTEHGLAPsHU726LRe1WuDSFk=",
+          "dev": true,
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.6.4",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+              "integrity": "sha1-JnUZDM0bBwHsL2UqTQ09QA12wN0=",
+              "dev": true
             }
+          }
+        },
+        "iron": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz",
+          "integrity": "sha1-WR2RiiVAdTxEbY5DfNzwz6gBEU8=",
+          "dev": true
+        },
+        "items": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/items/-/items-1.1.0.tgz",
+          "integrity": "sha1-rZ1VhAsimGDLPRYLMidMLUvZ4mI=",
+          "dev": true
+        },
+        "joi": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-6.4.1.tgz",
+          "integrity": "sha1-9Q9CRTVgBo5jg9oVrC0w3Xzra24=",
+          "dev": true,
+          "dependencies": {
+            "isemail": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+              "integrity": "sha1-4Mj23D9HCX53dzlcaJYnGqJWw7U=",
+              "dev": true
+            },
+            "moment": {
+              "version": "2.10.3",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz",
+              "integrity": "sha1-CruZ8wf2UhgwjGk17+KcV7Ggon8=",
+              "dev": true
+            }
+          }
+        },
+        "kilt": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz",
+          "integrity": "sha1-d7SmFjyn+lshN6iMFzNCFuwj1ds=",
+          "dev": true
+        },
+        "mimos": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
+          "integrity": "sha1-wyQXF+dblZkr54esfdbbGptTmx4=",
+          "dev": true,
+          "dependencies": {
+            "mime-db": {
+              "version": "1.14.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.14.0.tgz",
+              "integrity": "sha1-1WHxC27mbbUflK5leilRp0IX7YM=",
+              "dev": true
+            }
+          }
+        },
+        "peekaboo": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz",
+          "integrity": "sha1-wNspJq1lTSygH3ymUKtFkadk/EI=",
+          "dev": true
+        },
+        "qs": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+          "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc=",
+          "dev": true
+        },
+        "shot": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/shot/-/shot-1.5.3.tgz",
+          "integrity": "sha1-SGEHREO8VHLCNRthpGtOrsAH9Xo=",
+          "dev": true
+        },
+        "statehood": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/statehood/-/statehood-2.1.1.tgz",
+          "integrity": "sha1-AfFwtmxeklqvZ5qdMiulkYb8AAk=",
+          "dev": true
+        },
+        "subtext": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/subtext/-/subtext-1.1.1.tgz",
+          "integrity": "sha1-DJGCWuZdUXhVWT2DHjPvdaKEFWs=",
+          "dev": true,
+          "dependencies": {
+            "content": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/content/-/content-1.0.1.tgz",
+              "integrity": "sha1-gD60s7eJVGD9jGnGhMd1RmmvG6E=",
+              "dev": true
+            },
+            "pez": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
+              "integrity": "sha1-hEMYpc5wku7d/6KV4YB5rHefoBg=",
+              "dev": true,
+              "dependencies": {
+                "b64": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz",
+                  "integrity": "sha1-tZlbJPR+v9nxMQF6bntdZHVvtvM=",
+                  "dev": true
+                },
+                "nigel": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
+                  "integrity": "sha1-RjmJr4gSePuqHTzJOCPb0XtDYKE=",
+                  "dev": true,
+                  "dependencies": {
+                    "vise": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz",
+                      "integrity": "sha1-KDRb5N5aNB4V/SgW/Z6j5zA+jfM=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "topo": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz",
+          "integrity": "sha1-QhV8N8HeTTeIPM3R1skChHqGDbk=",
+          "dev": true
+        },
+        "vision": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/vision/-/vision-2.0.1.tgz",
+          "integrity": "sha1-0BIlW6buQm0GlqNOHfMy/sVeZzw=",
+          "dev": true
+        },
+        "wreck": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.0.0.tgz",
+          "integrity": "sha1-T0CGaWHl14rOBPMqa38x8/PFFjg=",
+          "dev": true
+        }
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0="
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "has-gulplog": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "hasha": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+      "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+      "dev": true
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+        }
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "dev": true
+    },
+    "hr": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/hr/-/hr-0.1.3.tgz",
+      "integrity": "sha1-2aow9ZKdq/0LZbo5WTij4YTbyv4=",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dependencies": {
+        "domutils": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8="
+        },
+        "entities": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+          "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "http-parser-js": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
+      "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE="
+    },
+    "http2": {
+      "version": "https://github.com/node-apn/node-http2/archive/apn-2.1.4.tar.gz",
+      "integrity": "sha1-gzPe4tbgCJFSzvrTD0HO1QL5w2Y="
+    },
+    "https-proxy-agent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "dev": true
+    },
+    "i": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true
+        }
+      }
+    },
+    "inquirer-confirm": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/inquirer-confirm/-/inquirer-confirm-0.2.2.tgz",
+      "integrity": "sha1-b0BtA3v52eRV7w+VOSnzV/6aiEg=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+          "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "2.9.24",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz",
+          "integrity": "sha1-FKLnXwVIMj3DWqRA2SAHyhVOlnw=",
+          "dev": true
+        },
+        "cli-width": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
+          "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
+          "dev": true
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.2.tgz",
+          "integrity": "sha1-QVhlSOHF2bP4HfcyUDS6rKtvWKs=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+          "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
+          "dev": true
+        },
+        "readline2": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+          "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
+          "dev": true
+        },
+        "rx": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
+          "integrity": "sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+          "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
+          "dev": true
+        }
+      }
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
+    },
+    "invariant": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "dev": true
+    },
+    "is": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
+      "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
+      "dev": true
+    },
+    "is-absolute": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+      "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ=="
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "is-relative": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+      "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+      "dev": true
+    },
+    "is-text-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+      "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-unc-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isemail": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+      "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jasmine": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
+      "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
+      "dev": true
+    },
+    "jasmine-core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
+      "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
+      "dev": true
+    },
+    "joi": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
+      "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY="
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json2yaml": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/json2yaml/-/json2yaml-1.1.0.tgz",
+      "integrity": "sha1-VBTZB/mBZYa4DFE+wuOusquBmmw=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+    },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true
+    },
+    "jsonwebtoken": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
+      "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dependencies": {
+        "extsprintf": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
+      "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU="
+    },
+    "jws": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
+      "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI="
+    },
+    "kew": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true
+    },
+    "largest-semantic-change": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/largest-semantic-change/-/largest-semantic-change-1.0.0.tgz",
+      "integrity": "sha1-JdxTi9qqi73DAnax6/kC1Ho0vw4=",
+      "dev": true,
+      "dependencies": {
+        "check-more-types": {
+          "version": "2.23.0",
+          "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.23.0.tgz",
+          "integrity": "sha1-YiYmTTCxCVqhwKW4dO291dLQpm8=",
+          "dev": true
+        },
+        "lazy-ass": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.5.0.tgz",
+          "integrity": "sha1-yhW+JDx8R1uFZc2/oPnC83TyoB0=",
+          "dev": true
+        }
+      }
+    },
+    "lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+      "dev": true
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "dev": true
+    },
+    "liftoff": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
+      "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
+      "dev": true
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._basetostring": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+      "dev": true
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+      "dev": true
+    },
+    "lodash._escapehtmlchar": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+      "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
+      "dev": true
+    },
+    "lodash._escapestringchar": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+      "integrity": "sha1-7P4iYYoq3lC/7qQ5N+Ud9m8O23I=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._htmlescapes": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
+      "integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash._isnative": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+      "dev": true
+    },
+    "lodash._objecttypes": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
+      "dev": true
+    },
+    "lodash._reescape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+      "dev": true
+    },
+    "lodash._reevaluate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+      "dev": true
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "lodash._reunescapedhtml": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+      "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
+      "dev": true,
+      "dependencies": {
+        "lodash.keys": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+          "dev": true
+        }
+      }
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+      "dev": true
+    },
+    "lodash._shimkeys": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+      "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true
+    },
+    "lodash.defaults": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+      "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
+      "dev": true,
+      "dependencies": {
+        "lodash.keys": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+          "dev": true
+        }
+      }
+    },
+    "lodash.escape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+      "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isobject": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true
+    },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
+      "dev": true
+    },
+    "lodash.mapvalues": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
+      "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "dev": true
+    },
+    "lodash.template": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "dev": true
+    },
+    "lodash.templatesettings": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "dev": true
+    },
+    "lodash.values": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
+      "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
+      "dev": true,
+      "dependencies": {
+        "lodash.keys": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+          "dev": true
+        }
+      }
+    },
+    "loglevel": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.1.tgz",
+      "integrity": "sha1-lbOD+Ro8J1b9SrCTZn5DCRYfK80=",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew=="
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
+      "dev": true
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "merge": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "dev": true
+    },
+    "meteor-promise": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/meteor-promise/-/meteor-promise-0.8.6.tgz",
+      "integrity": "sha512-HP6tOr67z/9XU2Dr0F2SSr8WRTuE23AG9Dj578DCJPEYHs67OLKBviU8A8rwvbwMD7Lu2+Of+yAMz2Wd8r4yxg==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo="
+    },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true
+        }
+      }
+    },
+    "modify-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
+      "integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI=",
+      "dev": true
+    },
+    "moment": {
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
+      "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8="
+    },
+    "moment-timezone": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
+      "integrity": "sha1-mc5cfYJyYusPH3AgRBd/YHRde5A=",
+      "dev": true
+    },
+    "mout": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mout/-/mout-1.1.0.tgz",
+      "integrity": "sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw=="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multipipe": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+    },
+    "natives": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+      "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
+      "dev": true
+    },
+    "ncp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+      "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
+      "dev": true
+    },
+    "node-forge": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
+      "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA="
+    },
+    "node-metainspector": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-metainspector/-/node-metainspector-1.3.0.tgz",
+      "integrity": "sha1-4SoiJyMmYz7U1STxsrQG6x3NU18=",
+      "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
+        },
+        "assert-plus": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+        },
+        "aws-sign2": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM="
+        },
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+        },
+        "caseless": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz",
+          "integrity": "sha1-7WsnGa3NH9GPWNwIHA8aW0OWOQk="
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+        },
+        "extend": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
+          "integrity": "sha1-HugBBonnOV/5RIJByYZSvHWagmA="
+        },
+        "form-data": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+          "dependencies": {
+            "mime-types": {
+              "version": "2.1.17",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+              "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo="
+            }
+          }
+        },
+        "har-validator": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+          "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI="
+        },
+        "hawk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+          "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8="
+        },
+        "http-signature": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+          "integrity": "sha1-F5bPZ6ABrVzWhJ3KCZFIXwkIn+Y="
+        },
+        "mime-types": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+          "dependencies": {
+            "mime-db": {
+              "version": "1.12.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+              "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
+            }
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        },
+        "qs": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
+          "integrity": "sha1-0OmudFIzoS3EP7TzBVu6RGJhFTw="
+        },
+        "request": {
+          "version": "2.58.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
+          "integrity": "sha1-tfScC5Sqt/rTiGEqH7atA7bMFYA="
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+        }
+      }
+    },
+    "node-notifier": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
+      "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+      "dev": true
+    },
+    "node-pre-gyp": {
+      "version": "0.6.36",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
+      "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y="
+    },
+    "node.extend": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
+      "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+      "dev": true
+    },
+    "nopt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00="
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true
+    },
+    "npm-build-tools": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/npm-build-tools/-/npm-build-tools-2.2.5.tgz",
+      "integrity": "sha1-/EqZ8g6CO2uULQtXy7IejQAMRfc=",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true
+        }
+      }
+    },
+    "npm-install-package": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/npm-install-package/-/npm-install-package-2.1.0.tgz",
+      "integrity": "sha1-1+/jz816sAYUuJbqUxGdyaslkSU=",
+      "dev": true
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg=="
+    },
+    "nth-check": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ="
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
+      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+      "dev": true
+    },
+    "object.defaults": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "dev": true,
+      "dependencies": {
+        "for-own": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true
+    },
+    "orchestrator": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+      "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+          "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+          "dev": true
+        },
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "dev": true
+        }
+      }
+    },
+    "ordered-read-streams": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+      "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ="
+    },
+    "p-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+      "dev": true
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
+    "pad-right": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+      "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
+      "dev": true
+    },
+    "parse-filepath": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
+      "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
+      "dev": true,
+      "dependencies": {
+        "is-absolute": {
+          "version": "0.2.6",
+          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+          "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+          "dev": true
+        },
+        "is-relative": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+          "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+          "dev": true
+        }
+      }
+    },
+    "parse-github-repo-url": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
+      "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
+      "dev": true
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
+    },
+    "part-up-js-models": {
+      "version": "git://github.com/part-up/js-models.git#a6ea85deb725bbebd15e789fed059016e5c05b40"
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "dev": true
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "phantomjs-prebuilt": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.13.tgz",
+      "integrity": "sha1-ZlVq2ell2JPKWn3J52PffoaX920=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true
+        },
+        "bl": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+          "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+          "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+          "dev": true
+        },
+        "concat-stream": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+          "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true
+        },
+        "debug": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+          "dev": true
+        },
+        "extract-zip": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
+          "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
+          "dev": true
+        },
+        "form-data": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "dev": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+          "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.74.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+          "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+          "dev": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+          "dev": true
+        },
+        "which": {
+          "version": "1.2.14",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+          "dev": true
+        }
+      }
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true
+    },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
+    },
+    "plugin-error": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+      "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+      "dev": true,
+      "dependencies": {
+        "arr-diff": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+          "dev": true
+        },
+        "array-slice": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+          "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+          "dev": true
+        }
+      }
+    },
+    "plugin-log": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/plugin-log/-/plugin-log-0.1.0.tgz",
+      "integrity": "sha1-hgSc9qsQgzOYqTHzaJy67nteEzM=",
+      "dev": true
+    },
+    "pluralize": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-5.1.0.tgz",
+      "integrity": "sha1-WGo5RKdsSB+Jd091VlJ3n2HWkrI="
+    },
+    "pop-iterate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",
+      "integrity": "sha1-zqz9q0q/NT16DyqqLB/Hs/lBO6M=",
+      "dev": true
+    },
+    "powercheck": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/powercheck/-/powercheck-1.1.0.tgz",
+      "integrity": "sha1-dqNPb5hH1mZ36ssGUQ8WYofGA+A="
+    },
+    "pre-git": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/pre-git/-/pre-git-3.16.0.tgz",
+      "integrity": "sha1-p2VrxfJ3GF/SE8ePOfJPLLYD62E=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "shelljs": {
+          "version": "0.7.8",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+          "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true
+        }
+      }
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "pretty-hrtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+      "dev": true
+    },
+    "prettyjson": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
+      "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true
+    },
+    "prompt": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
+      "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
+      "dev": true,
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+          "dev": true
+        },
+        "winston": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+          "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
+          "dev": true,
+          "dependencies": {
+            "colors": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+              "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+              "dev": true
+            },
+            "pkginfo": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+              "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "quote": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
+      "integrity": "sha1-EIOSF/bBNiuJGUBE0psjP9fzLwE=",
+      "dev": true
+    },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
+      "dev": true
+    },
+    "randomatic": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "dev": true,
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true
+        }
+      }
+    },
+    "rc": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
+      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ=="
+    },
+    "readdirp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "dev": true
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "dependencies": {
+        "mute-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+          "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+          "dev": true
+        }
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true
+    },
+    "regenerate": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+      "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "dev": true
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true
+    },
+    "regexpu-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "dev": true
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
+    "remedial": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.7.tgz",
+      "integrity": "sha1-1mdEE6ZWdgB74A3UAJgJh7LDAME=",
+      "dev": true
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true
+    },
+    "replace-ext": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+      "dev": true
+    },
+    "request": {
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw=="
+    },
+    "request-progress": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
+      "dev": true
+    },
+    "requestretry": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.5.0.tgz",
+      "integrity": "sha1-7RV7ulNSbt6z7DKo5wSkmYvs5ic=",
+      "dev": true
+    },
+    "require-dir": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.2.tgz",
+      "integrity": "sha1-wdXHXp+//eny5rM+OD209ZS1pqk=",
+      "dev": true
+    },
+    "require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true
+    },
+    "resolve-dir": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true
+    },
+    "revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
+      "dev": true
+    },
+    "rgb2hex": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.0.tgz",
+      "integrity": "sha1-zNVfhgrgxcTqN1BLlY5ELY0SMls=",
+      "dev": true
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true
+    },
+    "right-pad": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
+      "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w=="
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true
+    },
+    "run-sequence": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
+      "integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
+      "dev": true
+    },
+    "rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+      "dev": true
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "saucelabs": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.4.0.tgz",
+      "integrity": "sha1-uTSpr52ih0s/QKrh/N5QpEZvXzg=",
+      "dev": true
+    },
+    "selenium-standalone": {
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-5.11.2.tgz",
+      "integrity": "sha1-ckzKpy+ybzcR4OIJieR4xBM9+EQ=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true
+        },
+        "async": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
+          "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA=",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+          "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "dev": true,
+          "dependencies": {
+            "commander": {
+              "version": "2.12.2",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+              "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+              "dev": true
+            }
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "3.9.3",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
+          "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
+          "integrity": "sha1-zfIl6ImPhAolje1E/JF3Z3Cv3JM=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true,
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        },
+        "qs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.79.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+          "dev": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+          "dev": true
+        },
+        "which": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
+          "integrity": "sha1-nOUSRZlGFm4SwIPwjsBzOA/Iy7s=",
+          "dev": true
         },
         "yauzl": {
-            "version": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-            "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-            "dev": true,
-            "requires": {
-                "fd-slicer": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
-            }
-        },
-        "zip-stream": {
-            "version": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.1.1.tgz",
-            "integrity": "sha1-Uha0i7tNJlH2TVxubwnrSnOZ1Vc=",
-            "dev": true,
-            "requires": {
-                "archiver-utils": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
-                "compress-commons": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.0.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
-            }
+          "version": "2.9.1",
+          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
+          "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+          "dev": true
         }
+      }
+    },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+    },
+    "semver-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
+      "integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=",
+      "dev": true
+    },
+    "sequencify": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+      "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
+      "integrity": "sha1-N5zM+1a5HIYB5HkzVutTgpJN6a0=",
+      "dev": true
+    },
+    "shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-commit-message": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/simple-commit-message/-/simple-commit-message-3.3.2.tgz",
+      "integrity": "sha512-e382vZ4DDnOsgEsqCyg7rHNKHkeWGxhEe9h4qQlRyWMjS2aNQzjitnMqA3oQvkY3UMeULlKPDlI9jt3J+NJ4Wg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true
+        },
+        "ggit": {
+          "version": "1.23.1",
+          "resolved": "https://registry.npmjs.org/ggit/-/ggit-1.23.1.tgz",
+          "integrity": "sha1-5RPC8iKmJJpG5NDfNUuGBLW67ts=",
+          "dev": true,
+          "dependencies": {
+            "debug": {
+              "version": "2.6.8",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+              "dev": true
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+          "dev": true,
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.4",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        },
+        "moment": {
+          "version": "2.18.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+          "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "pluralize": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-6.0.0.tgz",
+          "integrity": "sha1-2bUa+tl9PVEHXMHdupsTLKzMt7o=",
+          "dev": true
+        },
+        "q": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
+          "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
+          "dev": true
+        },
+        "ramda": {
+          "version": "0.24.1",
+          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
+          "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true
+        },
+        "run-async": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+          "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+          "dev": true
+        },
+        "rx-lite": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+          "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+          "dev": true
+        }
+      }
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
+    "slug": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/slug/-/slug-0.9.1.tgz",
+      "integrity": "sha1-rwj2CKfBFRa2F3iqgA3OhMUYz9o="
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+      "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true
+    },
+    "source-map-url": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
+      "dev": true
+    },
+    "sparkles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+      "dev": true
+    },
+    "spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "dev": true
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true
+    },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "dev": true
+    },
+    "spots": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/spots/-/spots-0.5.0.tgz",
+      "integrity": "sha1-t6oPGsOJpabVfCHpjaHVODlAX+E=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M="
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "stream-consume": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
+      "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
+      "dev": true
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true
+    },
+    "strip-bom-buf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
+      "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+      "dev": true
+    },
+    "strip-bom-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-3.0.0.tgz",
+      "integrity": "sha1-lWvMXYRDD2klapDtgjdlzYWOFZw=",
+      "dev": true,
+      "dependencies": {
+        "first-chunk-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+          "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
+          "dev": true
+        }
+      }
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
+    },
+    "tar-pack": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
+      "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg=="
+    },
+    "tar-stream": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
+      "integrity": "sha1-+8bG6DwaGdTLSMfZYXH8JI7/x78=",
+      "dev": true,
+      "dependencies": {
+        "bl": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+          "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+          "dev": true
+        }
+      }
+    },
+    "tempfile": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
+      "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
+      "dev": true,
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+          "dev": true
+        }
+      }
+    },
+    "text-extensions": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
+      "integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
+      "dev": true
+    },
+    "throttleit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "dev": true
+    },
+    "tildify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+      "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
+      "dev": true
+    },
+    "time-stamp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
+    },
+    "topo": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+      "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU="
+    },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE="
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "trim-off-newlines": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "uid-number": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+    },
+    "underscore.deep": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/underscore.deep/-/underscore.deep-0.5.1.tgz",
+      "integrity": "sha1-ByZx9I1oc1w0Ij/P72PmnlJ2zCs="
+    },
+    "underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+      "dev": true
+    },
+    "unicode": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/unicode/-/unicode-10.0.0.tgz",
+      "integrity": "sha1-5dUcHbk7bHGguHngsMSvfm/faI4="
+    },
+    "unique-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+      "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-2.1.1.tgz",
+      "integrity": "sha1-6z+FBfRolpv5LLec6M6qwu1mdmE="
+    },
+    "urijs": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.16.1.tgz",
+      "integrity": "sha1-hZrTGJD1+VKHJ76J8ZMslPtHMeI=",
+      "dev": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        }
+      }
+    },
+    "user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "utile": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
+      "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
+      "dev": true,
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        }
+      }
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+    },
+    "v8flags": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "dev": true
+    },
+    "validate-commit-msg": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/validate-commit-msg/-/validate-commit-msg-2.14.0.tgz",
+      "integrity": "sha1-5Tg2kQEsuycNzAvCpO/+vhSJDqw=",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "dev": true
+    },
+    "validator": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-9.1.2.tgz",
+      "integrity": "sha512-1Tml6crNdsSC61jHssWksQxq6C7MmSFCCmf99Eb+l/V/cwVlw4/Pg3YXBP1WKcHLsyqe3E+iJXUZgoTTQFcqQg==",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA="
+    },
+    "vinyl": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+      "dev": true
+    },
+    "vinyl-fs": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+      "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+      "dev": true,
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+          "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "dev": true
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "dev": true
+        }
+      }
+    },
+    "wdio-dot-reporter": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/wdio-dot-reporter/-/wdio-dot-reporter-0.0.9.tgz",
+      "integrity": "sha1-kpsq2v1J1rBTT9oGjocxm0fjj+U=",
+      "dev": true
+    },
+    "wdio-sync": {
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/wdio-sync/-/wdio-sync-0.6.14.tgz",
+      "integrity": "sha1-odzVkHuh0EFUquYXbGItkQw8qbM=",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+          "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
+    "weak-map": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz",
+      "integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes=",
+      "dev": true
+    },
+    "webdriverio": {
+      "version": "4.9.11",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-4.9.11.tgz",
+      "integrity": "sha1-qChxPFpEvpmvvgfrW1I9XszQS0Q=",
+      "dev": true,
+      "dependencies": {
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.0.1.tgz",
+          "integrity": "sha512-7FQGOlSQ+AQxBNXJpVDj8efTA/FtyB5wcNE1omXXJ0cq6jm1jjDwuROlYDbnzHqdNPqliWFhcioCWSyav+xBnA==",
+          "dev": true
+        }
+      }
+    },
+    "websocket-driver": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "dev": true
+    },
+    "websocket-extensions": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+      "dev": true
+    },
+    "wgxpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wgxpath/-/wgxpath-1.0.0.tgz",
+      "integrity": "sha1-7vikudVYzEla06mit1FZfs2a9pA=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg=="
+    },
+    "wide-align": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w=="
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
+    },
+    "winston": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+        }
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xolvio-ddp": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/xolvio-ddp/-/xolvio-ddp-0.12.3.tgz",
+      "integrity": "sha1-NqarlhKyQLWg0cCoNJCK8XwLjwI=",
+      "dev": true,
+      "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+          "dev": true
+        },
+        "assert-plus": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+          "dev": true
+        },
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+          "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+          "integrity": "sha1-t7Zc5r8UE4hlOc/VM/CzDv+pz4g=",
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true
+        },
+        "delayed-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+          "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA=",
+          "dev": true
+        },
+        "form-data": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+          "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
+          "dev": true
+        },
+        "hawk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+          "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+          "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+          "dev": true
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+          "integrity": "sha1-fb6uRPbKRU4fFoRR1jB0ZzWBPOM=",
+          "dev": true
+        },
+        "qs": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.53.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+          "integrity": "sha1-GAo66St7Y5gC5PlUXdj83rcddgw=",
+          "dev": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+          "dev": true
+        }
+      }
+    },
+    "xolvio-fiber-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/xolvio-fiber-utils/-/xolvio-fiber-utils-2.0.3.tgz",
+      "integrity": "sha1-vsjXDHQGGjFjFbun0w0lyz6C3FA=",
+      "dev": true,
+      "dependencies": {
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "dev": true
+        }
+      }
+    },
+    "xolvio-jasmine-expect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xolvio-jasmine-expect/-/xolvio-jasmine-expect-1.1.0.tgz",
+      "integrity": "sha1-vCud1ghCMR8EV59agtzqaisxnH0=",
+      "dev": true
+    },
+    "xolvio-sync-webdriverio": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/xolvio-sync-webdriverio/-/xolvio-sync-webdriverio-9.0.1.tgz",
+      "integrity": "sha1-WRri2MiqynQiZJWfzM+QtPndUWA=",
+      "dev": true,
+      "dependencies": {
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "dev": true
+        }
+      }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "dev": true
+    },
+    "zip-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "dev": true
     }
+  }
 }


### PR DESCRIPTION
The update of sanitize-html comes with postcss for inline-style parsing. postcss includes ansi-style written in ES6. As packaegs won't get transpiled it gives an error in IE.