### PR TITLE
fix(client): Make more menu available to update owner

### DIFF
--- a/app/packages/partup-client-pages/app/partup/activities/activity/view/view.html
+++ b/app/packages/partup-client-pages/app/partup/activities/activity/view/view.html
@@ -247,6 +247,8 @@
         <a data-star-activity>{{_ 'star'}}</a>
       </li>
       {{/if}}
+      {{/if }}
+      {{#if isOwnActivity }}
       <li class="pu-dropdown-item">
         <a data-edit>{{_ 'edit' }}</a>
       </li>

--- a/app/packages/partup-client-pages/app/partup/activities/activity/view/view.js
+++ b/app/packages/partup-client-pages/app/partup/activities/activity/view/view.js
@@ -193,6 +193,9 @@ Template.ActivityView.helpers({
             updateIsStarred() {
                 return instance.updateIsStarred.get();
             },
+            isOwnActivity() {
+              return instance.update.upper_id === Meteor.userId();
+            },
         };
     },
 });

--- a/app/packages/partup-client-update/types/message-added.html
+++ b/app/packages/partup-client-update/types/message-added.html
@@ -13,7 +13,7 @@
 
     <section>
         <article class="pu-block pu-block-message">
-            {{#if isUpper }}
+            {{#if hasMenuEntries }}
                 <div class="more-options">
                         <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="25px" width="40px" id="Layer_1" style="enable-background:new 0 0 40 25;" version="1.1" viewBox="0 0 40 25"  xml:space="preserve" data-dropdown-open>
                             <circle cx="11" cy="12.5" r="2.5" style="fill:#2F3435;"/>
@@ -38,9 +38,7 @@
                 {{/if }}
             {{/ if}}
         </article>
-
     </section>
-
 </template>
 
 

--- a/app/packages/partup-client-update/types/message-added.js
+++ b/app/packages/partup-client-update/types/message-added.js
@@ -20,6 +20,11 @@ Template.update_partups_message_added.onCreated(function() {
 });
 
 Template.update_partups_message_added.helpers({
+    hasMenuEntries() {
+      const { upper_id, partup_id } = Template.instance().data;
+      const user = Meteor.user();
+      return upper_id === user._id || User(user).isPartnerInPartup(partup_id);
+    },
     dropdownOpen: function() {
         return Template.instance().dropdownOpen;
     },


### PR DESCRIPTION
Show more menu when the user is able to see an entry instead of checking if the user is a supporter.

Time spend: 15mins
Closes: #1505 