### PR TITLE
Fix language bug

### DIFF
--- a/app/packages/partup-client-base/bootstrap.js
+++ b/app/packages/partup-client-base/bootstrap.js
@@ -51,23 +51,22 @@ Meteor.startup(function() {
     // or falls back to browser settings when user
     // logs in or out
     Meteor.autorun(function(computation) {
-        var user = Meteor.user();
-        var language = 'en';
+        if (Meteor.loggingIn()) {
+            return;
+        }
+
+        const user = Meteor.user();
+        let locale;
 
         if (user) {
-            // if the user is logged in, find the user language settings
-            var userLanguage = lodash.get(user, 'profile.settings.locale', 'en');
-            language = userLanguage;
+            locale = lodash.get(user, 'profile.settings.locale', 'en');
         } else {
-            // if the user is not logged in, get the browser language
-            var browserLanguage = Partup.client.language.getBrowserDefaultLocale();
-            language = browserLanguage;
+            locale = Partup.client.language.getBrowserDefaultLocale();
         }
 
         // make nonreactive to prevent template-rerender-flickering
         Tracker.nonreactive(function() {
-            // finally set the language of the partup interface
-            Partup.client.language.change(language);
+            Partup.client.language.change(locale);
         });
     });
 

--- a/app/packages/partup-client-base/client/language.js
+++ b/app/packages/partup-client-base/client/language.js
@@ -82,7 +82,7 @@ Partup.client.language = {
             });
 
             const user = Meteor.user();
-            if (user && User(user).getProperlocale() !== language) {
+            if (user && User(user).getProperLocale() !== language) {
               // Only update if there's actually a new language, reactiveness causes this to run many times.
               Meteor.call('settings.update', {locale: language}, function(err) {
                   if (err) {

--- a/app/packages/partup-client-base/client/language.js
+++ b/app/packages/partup-client-base/client/language.js
@@ -13,15 +13,15 @@ Partup.client.language = {
      * @memberof Partup.client.language
      * @param {String} language
      */
-    change: function(language) {
-        var self = this;
+    change(language) {
+        const self = this;
+        const currentLanguage = self.current.get();
 
-        // prevent unnessesary language changes
-        var currentLanguage = self.current.get();
-        if (language === currentLanguage) return;
+        if (language === currentLanguage) {
+          return;
+        }
 
         TAPi18n.setLanguage(language).done(function() {
-            // Change MomentJS language
             moment.locale(language);
             self.current.set(language);
             // Change datepicker language
@@ -81,17 +81,16 @@ Partup.client.language = {
                 shouldNotContainUrls:   TAPi18n.__('base-client-language-ss-shouldNotContainUrls'),
             });
 
-            var user = Meteor.user();
-            if (!user) return;
-
-            // update the user stored language setting for future logins
-            Meteor.call('settings.update', {locale: language}, function(err) {
-                if (err) {
-                    Partup.client.notify.error('Could not set the correct language');
-                    return;
-                }
-            });
-
+            const user = Meteor.user();
+            if (user && User(user).getProperlocale() !== language) {
+              // Only update if there's actually a new language, reactiveness causes this to run many times.
+              Meteor.call('settings.update', {locale: language}, function(err) {
+                  if (err) {
+                      Partup.client.notify.error('Could not set the correct language');
+                      return;
+                  }
+              });
+            }
         }).fail(function(error_message) {
             Partup.client.notify.error('Could not load the language "' + language + '"');
         });

--- a/app/packages/partup-lib/collections/users.js
+++ b/app/packages/partup-lib/collections/users.js
@@ -505,6 +505,10 @@ User = function(user) {
             return locale;
         },
 
+        getProperLocale() {
+            return _.get(user, 'profile.settings.locale');
+        },
+
         /**
          * Get users email address
          *


### PR DESCRIPTION
Disabled setting the locale when a user is in the middle of the logging in process. This caused the handler to be ran twice and trigger a race condition. The race condition was caused by always updating the user object in the database even when the user already had the locale that was being updated. That triggered the handler to be ran again and got in a loop until they were the same as the cached language.

Complexity: 25
Time spent: 7hrs~

Closes: #1502 