### PR TITLE
fix(update): Always get the user on update detail

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -96,7 +96,7 @@
     "aria-query": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.7.0.tgz",
-      "integrity": "sha512-/r2lHl09V3o74+2MLKEdewoj37YZqiQZnfen1O4iNlrOjUgeKuu1U2yF3iKh6HJxqF+OXkLMfQv65Z/cvxD6vA==",
+      "integrity": "sha1-SvEKHmFXPd6gzzuZtRxSwFtCTSQ=",
       "dev": true,
       "requires": {
         "ast-types-flow": "0.0.7"
@@ -816,7 +816,7 @@
     "emoji-regex": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-      "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
+      "integrity": "sha1-m66pKbFVVlwR6kHGYm6qZc75ksI=",
       "dev": true
     },
     "encoding": {
@@ -1076,7 +1076,7 @@
     "eslint-config-airbnb": {
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-15.1.0.tgz",
-      "integrity": "sha512-m0q9fiMBzDAIbirlGnpJNWToIhdhJmXXnMG+IFflYzzod9231ZhtmGKegKg8E9T8F1YuVaDSU1FnCm5b9iXVhQ==",
+      "integrity": "sha1-/UMpZakG4wE5ABuoMPWPc67dro4=",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "11.3.2"
@@ -1085,7 +1085,7 @@
     "eslint-config-airbnb-base": {
       "version": "11.3.2",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.2.tgz",
-      "integrity": "sha512-/fhjt/VqzBA2SRsx7ErDtv6Ayf+XLw9LIOqmpBuHFCVwyJo2EtzGWMB9fYRFBoWWQLxmNmCpenNiH0RxyeS41w==",
+      "integrity": "sha1-hwOxGr48iKx+wrdFt/31LgCuaAo=",
       "dev": true,
       "requires": {
         "eslint-restricted-globals": "0.1.1"
@@ -1120,7 +1120,7 @@
     "eslint-module-utils": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "integrity": "sha1-q67IJBd2E7ipWymWOeG2+s9HNEk=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -1136,7 +1136,7 @@
     "eslint-plugin-import": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
-      "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
+      "integrity": "sha1-+htu8x/LPFAcCYWcG4bx/FuYaJQ=",
       "dev": true,
       "requires": {
         "builtin-modules": "1.1.1",
@@ -1166,7 +1166,7 @@
     "eslint-plugin-jsx-a11y": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.1.1.tgz",
-      "integrity": "sha512-5I9SpoP7gT4wBFOtXT8/tXNPYohHBVfyVfO17vkbC7r9kEIxYJF12D3pKqhk8+xnk12rfxKClS3WCFpVckFTPQ==",
+      "integrity": "sha1-XJa7UYbKFOlNsQlf9Zs+K9lAabE=",
       "dev": true,
       "requires": {
         "aria-query": "0.7.0",
@@ -1623,7 +1623,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
       "dev": true
     },
     "htmlparser2": {
@@ -2767,7 +2767,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -2987,7 +2987,7 @@
     "prettier": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
-      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
+      "integrity": "sha1-lrwhMvejIzjmB4rrKXJxeMYzWCc=",
       "dev": true
     },
     "private": {
@@ -3215,7 +3215,7 @@
     "resolve": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "integrity": "sha1-HwmsznlsmnYlefMbLBzEw83fnzY=",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"

--- a/app/packages/partup-client-update/Update.js
+++ b/app/packages/partup-client-update/Update.js
@@ -11,10 +11,15 @@ Template.Update.onCreated(function() {
   // Stored seperately to avoid being called every second (time ticks)
   this.updated_at = get(this.data.update, 'updated_at');
 
+  this.updateUpper = new ReactiveVar();
+
   const upperId = get(this.data.update, 'upper_id');
-  const user = Meteor.users.findOne(upperId);
-  if (upperId && !user) {
-    this.subscribe('users.one', upperId);
+  if (upperId) {
+    Meteor.call('users.one', upperId, (error, result) => {
+      if (result) {
+        this.updateUpper.set(result);
+      }
+    });
   }
 });
 
@@ -36,6 +41,7 @@ Template.Update.helpers({
     const templateInstance = Template.instance();
     const update = this.update;
     const partup = Partups.findOne(get(update, 'partup_id'));
+    const upper = templateInstance.updateUpper.get();
 
     if (!update || !partup) {
       return {};
@@ -43,11 +49,15 @@ Template.Update.helpers({
 
     return {
       title() {
+        if (!upper) {
+          return;
+        }
+
         const titleKey = `update-type-${update.type}-title`;
         const params = {};
 
         if (update.upper_id) {
-          params.name = User(Meteor.users.findOne(update.upper_id)).getFirstname();
+          params.name = User(upper).getFirstname();
         } else if (update.system) {
           params.name = 'Part-up';
         }
@@ -85,8 +95,7 @@ Template.Update.helpers({
           : Router.path('partup-update', { slug: partup.slug, update_id: update._id });
       },
       upperImageId() {
-        const user = Meteor.users.findSinglePublicProfile(update.upper_id).fetch().pop();
-        return get(user, 'profile.image');
+        return get(upper, 'profile.image');
       },
       templateName() {
         if (update.type === 'partups_activities_invited') {

--- a/app/packages/partup-client-update/Update.js
+++ b/app/packages/partup-client-update/Update.js
@@ -10,6 +10,12 @@ import { get, each } from 'lodash';
 Template.Update.onCreated(function() {
   // Stored seperately to avoid being called every second (time ticks)
   this.updated_at = get(this.data.update, 'updated_at');
+
+  const upperId = get(this.data.update, 'upper_id');
+  const user = Meteor.users.findOne(upperId);
+  if (upperId && !user) {
+    this.subscribe('users.one', upperId);
+  }
 });
 
 Template.Update.helpers({
@@ -79,7 +85,8 @@ Template.Update.helpers({
           : Router.path('partup-update', { slug: partup.slug, update_id: update._id });
       },
       upperImageId() {
-        return Meteor.users.findSinglePublicProfile(update.upper_id).fetch().pop().profile.image
+        const user = Meteor.users.findSinglePublicProfile(update.upper_id).fetch().pop();
+        return get(user, 'profile.image');
       },
       templateName() {
         if (update.type === 'partups_activities_invited') {

--- a/app/packages/partup-server/methods/users/users_methods.js
+++ b/app/packages/partup-server/methods/users/users_methods.js
@@ -415,5 +415,10 @@ Meteor.methods({
             user.emails.unshift(primary[0]);
             Meteor.users.update(user._id, {$set: {emails: user.emails}});
         }
+    },
+
+    'users.one'(userId) {
+      check(userId, String);
+      return Meteor.users.findSinglePublicProfile(userId).fetch().pop();
     }
 });


### PR DESCRIPTION
The update detail no longer relies on existing subscriptions. In some cases the user that triggered the update is no longer an upper or supporter in the given part-up which caused this bug.

Closes #1627 