### PR TITLE
fix(chats): Fixed match error when no chatId is present

### DIFF
--- a/app/packages/partup-server/publications/chats.js
+++ b/app/packages/partup-server/publications/chats.js
@@ -298,6 +298,7 @@ Meteor.publishComposite('chats.by_id', function(chatId, chatMessagesOptions) {
 
 Meteor.publishComposite('chats.by_id.for_web', function(chatId, chatMessagesOptions) {
     this.unblock();
+    if (!chatId) return; // Return if no chat specified in the URL
     check(chatId, String);
     chatMessagesOptions = chatMessagesOptions || {};
     check(chatMessagesOptions, {


### PR DESCRIPTION
A subscription would be created when navigating to /chats, this fixes the backend match failed