### PR TITLE
fix(comments): A profile image was reference by the image id stored in the comment

### DIFF
--- a/app/packages/partup-client-comments/Comments.js
+++ b/app/packages/partup-client-comments/Comments.js
@@ -243,17 +243,8 @@ Template.Comments.helpers({
         return newComments.length;
     },
     imageForComment: function() {
-        var commentImage = Images.findOne(this.creator.image);
-        if (commentImage) {
-            return this.creator.image;
-        } else {
-            commentUser = Meteor.users.findOne(this.creator._id);
-            if (commentUser) {
-                return commentUser.profile.image;
-            } else {
-                return '';
-            }
-        }
+        commentUser = Meteor.users.findOne(this.creator._id);
+        return commentUser ? commentUser.profile.image : '';
     },
     isUserComment: function() {
         return this.creator._id === Meteor.userId() ? 'data-comment' : '';


### PR DESCRIPTION
The profile image id was stored with the comment instead of getting it from a user itself that is
referenced in the comment.

fix #1553