### PR TITLE
fix(hovercard): Safeguard user finds in hovercards

### DIFF
--- a/app/packages/partup-client-hover-container/templates/upper.html
+++ b/app/packages/partup-client-hover-container/templates/upper.html
@@ -1,7 +1,11 @@
 <template name="HoverContainer_upper">
-    {{# if user }}
-        {{> UpperTile user=user hover=true }}
+  {{#if loading }}
+    {{> Spinner }}
+  {{ else }}
+    {{#if user }}
+      {{> UpperTile user=user hover=true }}
     {{ else }}
-        {{> Spinner }}
-    {{/ if }}
+      <p style="margin-bottom:-10px;">{{_ 'pages-app-notfound-profile-title'}}</p>
+    {{/if }}
+  {{/if }}
 </template>

--- a/app/packages/partup-client-hover-container/templates/upper.js
+++ b/app/packages/partup-client-hover-container/templates/upper.js
@@ -11,7 +11,7 @@ Template.HoverContainer_upper.onCreated(function() {
 Template.HoverContainer_upper.helpers({
     user() {
       var userId = Template.instance().data;
-      var user = (Meteor.users.findSinglePublicProfile(userId).fetch() || []).pop();
+      var user = Meteor.users.findSingleActivePublicProfile(userId).fetch().pop();
 
       if (!user) return;
 

--- a/app/packages/partup-client-hover-container/templates/upper.js
+++ b/app/packages/partup-client-hover-container/templates/upper.js
@@ -1,19 +1,28 @@
 Template.HoverContainer_upper.onCreated(function() {
-    var userId = this.data;
-    this.subscribe('users.one', userId);
+  const template = this;
+  template.loading = new ReactiveVar(true);
+  template.subscribe('users.one', template.data, {
+    onReady() {
+      template.loading.set(false);
+    }
+  });
 });
 
 Template.HoverContainer_upper.helpers({
-    user: function() {
-        var userId = Template.instance().data;
-        var user = Meteor.users.findOne(userId) || null;
-        if (!user) return;
+    user() {
+      var userId = Template.instance().data;
+      var user = (Meteor.users.findSinglePublicProfile(userId).fetch() || []).pop();
 
-        var image = Images.findOne(user.profile.image);
-        if (!image) return;
+      if (!user) return;
 
-        Partup.client.embed.user(user, [image]);
+      var image = Images.findOne(user.profile.image);
+      if (!image) return;
 
-        return user;
+      Partup.client.embed.user(user, [image]);
+
+      return user;
+    },
+    loading() {
+      return Template.instance().loading.get();
     }
 });

--- a/app/packages/partup-lib/collections/users.js
+++ b/app/packages/partup-lib/collections/users.js
@@ -93,6 +93,17 @@ Meteor.users.findSinglePublicProfile = function(userId) {
 };
 
 /**
+ * Find a user and expose it's public fields if not deleted or deactivated
+ *
+ * @memberOf Meteor.users
+ * @param {String} userId
+ * @return {Mongo.Cursor}
+ */
+Meteor.users.findSingleActivePublicProfile = function(userId) {
+    return Meteor.users.find({_id: userId, deactivatedAt: {$exists: false}, deletedAt: {$exists: false}}, {fields: getPublicUserFields()});
+};
+
+/**
  * Find users and expose their public fields
  *
  * @memberOf Meteor.users


### PR DESCRIPTION
Uses findSinglePublicProfile to guard deactivated/deleted users;
Disables the endless spinner when no user is found;