### PR TITLE
refactor(translation): Rename impersonation translation keys

### DIFF
--- a/app/packages/partup-client-pages/modal/profile_settings/advanced/advanced.html
+++ b/app/packages/partup-client-pages/modal/profile_settings/advanced/advanced.html
@@ -5,11 +5,11 @@
 
 
         <section class="pu-section">
-          <h4 class="pu-section-title">{{_ 'impersonation-title'}}</h4>
-          <p class="pu-section-description">{{_ 'impersonation-description'}}</p>
+          <h4 class="pu-section-title">{{_ 'modal-profilesettings-advanced-impersonation-title'}}</h4>
+          <p class="pu-section-description">{{_ 'modal-profilesettings-advanced-impersonation-description'}}</p>
           <p class="pu-impersonation" data-allow-impersonation>
             <input type="checkbox" name="impersonation" class="impersonate-checkbox">
-            <label for="impersonation">{{_ 'impersonation-label'}}</label>
+            <label for="impersonation">{{_ 'modal-profilesettings-advanced-impersonation-label'}}</label>
           </p>
         </section>
 


### PR DESCRIPTION
This corrects the phraseapp keys in code:

prefix: `modal-profilesettings-advanced-`
keys:
  - `impersonation-title`;
  - `impersonation-description`;
  - `impersonation-label`;