### PR TITLE
fix(activities): no longer copy archived and deleted activities

### DIFF
--- a/app/packages/partup-client-boardview/BoardView.js
+++ b/app/packages/partup-client-boardview/BoardView.js
@@ -74,7 +74,7 @@ Template.BoardView.onCreated(function() {
         const lanes = Lanes.find({ _id: { $in: board.lanes } })
           .map((lane) => {
             const order = [...lane.activities];
-            const laneActivities = Activities.find({ _id: { $in: lane.activities }, deleted_at: { $ne: true } }).fetch();
+            const laneActivities = Activities.find({ _id: { $in: lane.activities } }).fetch();
 
             each(order, (o, i) => {
               const ui = findIndex(laneActivities, (a) => a._id === o);

--- a/app/packages/partup-server/methods/activities/activities_methods.js
+++ b/app/packages/partup-server/methods/activities/activities_methods.js
@@ -187,6 +187,7 @@ Meteor.methods({
         check(activityId, String);
 
         var upper = Meteor.users.findOneOrFail(this.userId);
+
         var activity = Activities.findOneOrFail(activityId);
 
         if (activity.isRemoved()) throw new Meteor.Error(404, 'activity_could_not_be_found');
@@ -331,7 +332,7 @@ Meteor.methods({
             var board = Boards.findOneOrFail(toPartup.board_id);
             var backlogLane = Lanes.findOneOrFail(board.lanes[0]);
 
-            var existingActivities = Activities.find({partup_id: fromPartupId}).fetch();
+            var existingActivities = Activities.find({partup_id: fromPartupId, deleted_at: { $exists: false }, archived: { $ne: true }}).fetch();
             existingActivities.forEach(function(activity) {
                 var newActivity = {
                     name: activity.name,


### PR DESCRIPTION
Test case:
  - Create 3 activities in a part-up
    - 1 normal, 1 archived and 1 deleted;
  - Create a new Part-up and copy the activities from the partup above;
  - Create a new activity while in the part-up creation screen and delete it;
  - Finish the creation of the part-up and navigate to the board;
  - Create a new activity and delete it.

No archived or deleted activities should be visible.

Closes: #1699 