### PR TITLE
feat(impersonation): Improve impersonation flow

### DIFF
--- a/app/packages/partup-client-admin/Admin.html
+++ b/app/packages/partup-client-admin/Admin.html
@@ -38,9 +38,15 @@
                                     <button data-reactivate-user>reactivate</button>
                                 </li>
                             {{/if}}
-                            <li class="pu-dropdownitem pu-dropdownitem-small">
-                                <button data-impersonate-user>impersonate</button>
-                            </li>
+                            {{# if isActiveImpersonationRequest impersonationRequest }}
+                              <li class="pu-dropdownitem pu-dropdownitem-small">
+                                  <button data-impersonate-user>impersonate</button>
+                              </li>
+                            {{ else }}
+                              <li class="pu-dropdownitem pu-dropdownitem-small">
+                                <button data-request-impersonation>request impersonation</button>
+                              </li>
+                            {{/if }}
                         </ul>
                     </div>
                 </li>

--- a/app/packages/partup-client-pages/modal/profile_settings/advanced/advanced.html
+++ b/app/packages/partup-client-pages/modal/profile_settings/advanced/advanced.html
@@ -4,14 +4,16 @@
         <p>{{_ 'modal-profilesettings-advanced-text-explanation'}}</p>
 
 
+        {{#if showImpersonationRequest }}
         <section class="pu-section">
           <h4 class="pu-section-title">{{_ 'modal-profilesettings-advanced-impersonation-title'}}</h4>
-          <p class="pu-section-description">{{_ 'modal-profilesettings-advanced-impersonation-description'}}</p>
+          <p class="pu-section-description">{{_ 'modal-profilesettings-advanced-impersonation-description' name=requesterName }}</p>
           <p class="pu-impersonation" data-allow-impersonation>
             <input type="checkbox" name="impersonation" class="impersonate-checkbox">
             <label for="impersonation">{{_ 'modal-profilesettings-advanced-impersonation-label'}}</label>
           </p>
         </section>
+        {{/if }}
 
         <section class="pu-section">
           <button class="pu-button {{# if submitting }}pu-state-loading pu-state-disabled{{/ if }}" data-delete-account>

--- a/app/packages/partup-client-pages/modal/profile_settings/advanced/advanced.js
+++ b/app/packages/partup-client-pages/modal/profile_settings/advanced/advanced.js
@@ -1,25 +1,54 @@
-import { get } from 'lodash';
-
-
 Template.modal_profile_settings_advanced.onCreated(function() {
   this.submitting = new ReactiveVar(false);
+  this.submittingImpersonationRequest = new ReactiveVar(false);
+
   const { impersonation } = Partup.helpers;
 
-  const user = Meteor.user();
-  const lastImpersonationDate = impersonation.getLastDate(user);
-  const timeLeft = impersonation.timeLeft(lastImpersonationDate);
+  // Reactive in order to automatically hide the option to allow the request when the time expires.
+  this.impersonationRequest = new ReactiveVar(undefined, (oldVal, newVal) => {
+    if (newVal) {
+      if (impersonation.isActive(newVal)) {
+        Meteor.defer(() => {
+          const checkboxNode = this.find('.impersonate-checkbox');
+          if (checkboxNode) {
+            checkboxNode.checked = true;
+          }
+          Meteor.setTimeout(() => {
+            this.impersonationRequest.set(undefined);
+          }, impersonation.timeLeft(newVal));
+        });
+      }
 
-  if (timeLeft > 0) {
-    Meteor.defer(() => {
-      this.find('.impersonate-checkbox').checked = true;
-    });
-  }
+    }
+  });
+  Meteor.call('users.get_non_expired_impersonation_request', (error, result) => {
+    if (result) {
+      this.impersonationRequest.set(result);
+    }
+  });
 });
 
 Template.modal_profile_settings_advanced.helpers({
 	submitting: function() {
         return Template.instance().submitting.get();
   },
+  showImpersonationRequest() {
+    const { impersonation } = Partup.helpers;
+    const request = Template.instance().impersonationRequest.get();
+
+    return request && impersonation.timeLeft(request) > 0;
+  },
+  requesterName() {
+    const request = Template.instance().impersonationRequest.get();
+    if (!request) {
+      return;
+    }
+
+    const admin = Meteor.users.findOne(request.adminId);
+    return admin
+      ? User(admin).getFirstname()
+      : 'an admin';
+  }
 });
 /*************************************************************/
 /* Page events */
@@ -45,23 +74,30 @@ Template.modal_profile_settings_advanced.events({
     },
     'click [data-allow-impersonation]'(event, templateInstance) {
       event.preventDefault();
-      const checkboxNode = templateInstance.find('.impersonate-checkbox');
-
+      if (templateInstance.submittingImpersonationRequest.curValue) {
+        return;
+      }
       const { impersonation } = Partup.helpers;
-      const lastImpersonationDate = impersonation.getLastDate(Meteor.user());
-      const timeLeft = impersonation.timeLeft(lastImpersonationDate);
+      const impersonationRequest = templateInstance.impersonationRequest.curValue;
 
-      if (timeLeft > 0) {
-        Partup.client.notify.warning(TAPi18n.__(`impersonation-still-active`, { minutes: Math.floor(timeLeft / 60000) }));
+      templateInstance.submittingImpersonationRequest.set(true);
+
+      if (impersonation.isActive(impersonationRequest)) {
+        Partup.client.notify.warning(TAPi18n.__(`impersonation-still-active`, { minutes: Math.floor(impersonation.timeLeft(impersonationRequest) / 60000) }));
       } else {
+
         Meteor.call('users.allow_impersonation', (error, result) => {
           if (error) {
             Partup.client.notify.error(TAPi18n.__(error.reason));
+          } else if (result === -1) {
+            Partup.client.notify.error(TAPi18n.__('impersonation-error-cannot-allow'));
           } else {
-            checkboxNode.checked = true;
             Partup.client.notify.info(TAPi18n.__('impersonation-allow-success'));
+            templateInstance.impersonationRequest.set(result);
           }
+          templateInstance.submittingImpersonationRequest.set(false);
         });
+
       }
     },
 });

--- a/app/packages/partup-lib/collections/impersonationrequests.js
+++ b/app/packages/partup-lib/collections/impersonationrequests.js
@@ -1,0 +1,42 @@
+ImpersonationRequests = new Mongo.Collection('impersonationrequests');
+
+if (Meteor.isServer) {
+  ImpersonationRequests._ensureIndex('userId');
+};
+
+ImpersonationRequests.findOneActiveRequest = function(userId, status) {
+  const viewerId = Meteor.userId();
+
+  const query = {
+    userId: userId,
+    created_at: {
+      $gte: new Date((moment().subtract(30, 'minutes').toISOString()))
+    }
+  };
+
+  if (status) {
+    query.status = status;
+  }
+
+  const request = this.find(query, {
+    sort: { created_at: -1 },
+    limit: 1,
+  }).fetch().pop();
+
+  if (request && (request.userId === viewerId || request.adminId === viewerId)) {
+    return request;
+  }
+  return undefined;
+}
+
+ImpersonationRequests.findAcceptedRequests = function() {
+  const { impersonation } = Partup.helpers;
+
+  return this.find({
+    adminId: Meteor.userId(),
+    status: impersonation.IMPERSONATION_REQUEST_STATUS.ACCEPTED,
+    accepted_at: {
+      $gte: new Date((moment().subtract(30, 'minutes').toISOString()))
+    }
+  }).fetch();
+}

--- a/app/packages/partup-lib/helpers/impersonation.js
+++ b/app/packages/partup-lib/helpers/impersonation.js
@@ -1,23 +1,36 @@
-import _ from 'lodash';
-
 const impersonationDuration = 1800000; // 30mins
+
+export const IMPERSONATION_REQUEST_STATUS = {
+  PENDING: 'pending',
+  ACCEPTED: 'accepted',
+};
+
+const impersonation = Object.freeze({
+  durationMS: impersonationDuration,
+
+  IMPERSONATION_REQUEST_STATUS,
+
+  isActive(impersonationRequest = {}) {
+    const isAccepted = impersonationRequest.status === IMPERSONATION_REQUEST_STATUS.ACCEPTED;
+    const timeDiff = moment(impersonationRequest.created_at).diff(moment().subtract(30, 'minutes'));
+    const isWithin30MinutesOfCreationDate = timeDiff > 0 && timeDiff <= impersonationDuration;
+
+    return isAccepted && isWithin30MinutesOfCreationDate;
+  },
+  isExpired(impersonationRequest = {}) {
+    return moment(impersonationRequest.created_at).diff(moment().subtract(30, 'minutes')) <= 0;
+  },
+
+  timeLeft(impersonationRequest = {}) {
+    if (!impersonationRequest.created_at) {
+      return 0;
+    }
+    return moment(impersonationRequest.created_at).diff(moment().subtract(30, 'minutes')).valueOf();
+  },
+});
 
 if (!Partup.helpers) {
   Partup.helpers = {};
 }
-
-Partup.helpers.impersonation = {
-  durationMS: impersonationDuration,
-
-  getLastDate(user) {
-    return _.get(user, 'impersonation', []).splice(-1)[0];
-  },
-
-  timeLeft(impersonationDate) {
-    if (!impersonationDate) {
-      return 0;
-    }
-    return impersonationDuration - moment(new Date()).diff(moment(impersonationDate));
-  },
-
-};
+Partup.helpers.impersonation = impersonation;
+export default impersonation;

--- a/app/packages/partup-lib/helpers/impersonation.test.js
+++ b/app/packages/partup-lib/helpers/impersonation.test.js
@@ -1,0 +1,76 @@
+import impersonation, { IMPERSONATION_REQUEST_STATUS } from './impersonation';
+
+const validTime = () => moment().subtract((impersonation.durationMS * 0.5), 'ms');
+const invalidTime = () => moment().subtract((impersonation.durationMS + 1), 'ms');
+
+Tinytest.add(
+  `impersonation.isActive returns TRUE when status '${IMPERSONATION_REQUEST_STATUS.ACCEPTED}' and 'created_at' comparrison is above 0 and below ${impersonation.durationMS}`,
+  (test) => {
+    const sut = {
+      created_at: validTime(),
+      status: IMPERSONATION_REQUEST_STATUS.ACCEPTED,
+    };
+
+    test.equal(impersonation.isActive(sut), true);
+  },
+);
+
+Tinytest.add(
+  `impersonation.isActive returns FALSE when status '${IMPERSONATION_REQUEST_STATUS.ACCEPTED}' and request time is expired`,
+  (test) => {
+    const sut = {
+      created_at: invalidTime(),
+      status: IMPERSONATION_REQUEST_STATUS.ACCEPTED,
+    };
+
+    test.equal(impersonation.isActive(sut), false);
+  },
+);
+
+Tinytest.add(
+  `impersonation.isActive returns FALSE when status is not ${IMPERSONATION_REQUEST_STATUS.ACCEPTED} but timestamp is within the boundaries`,
+  (test) => {
+    const sut = {
+      created_at: validTime(),
+      status: 'doog pop',
+    };
+
+    test.equal(impersonation.isActive(sut), false);
+  }
+);
+
+Tinytest.add(
+  `impersonation.isExpired returns TRUE when timestamp comparrison returns 0 or less`,
+  (test) => {
+    const sut = {
+      created_at: invalidTime(),
+    };
+
+    test.equal(impersonation.isExpired(sut), true);
+  }
+);
+
+Tinytest.add(
+  `impersonation.isExpired returns FALSE when timestamp comparrison is within 0 and ${impersonation.durationMS}`,
+  (test) => {
+    const sut = {
+      created_at: validTime(),
+    };
+
+    test.equal(impersonation.isExpired(sut), false);
+  }
+);
+
+Tinytest.add(
+  `impersonation.timeLeft returns time in ms`,
+  (test) => {
+    const sut = {
+      created_at: moment().subtract(1, 'minutes'),
+    }
+
+    const timeLeft = impersonation.timeLeft(sut);
+    const isTrue = timeLeft > 0 && timeLeft < impersonation.durationMS;
+
+    test.equal(isTrue, true);
+  }
+)

--- a/app/packages/partup-lib/package.js
+++ b/app/packages/partup-lib/package.js
@@ -42,8 +42,9 @@ Package.onUse(function(api) {
         'services/validators.js',
         'services/website.js',
         'collections/activities.js',
-        'collections/invites.js',
         'collections/contributions.js',
+        'collections/impersonationrequests.js',
+        'collections/invites.js',
         'collections/updates.js',
         'collections/notifications.js',
         'collections/partup_user_settings.js',
@@ -143,6 +144,7 @@ Package.onUse(function(api) {
     api.export('Invites');
     api.export('Contributions');
     api.export('Images');
+    api.export('ImpersonationRequests');
     api.export('Temp');
     api.export('Networks');
     api.export('Notifications');
@@ -178,9 +180,10 @@ Package.onUse(function(api) {
 });
 
 Package.onTest(function(api) {
-  api.use(['ecmascript', 'underscore', 'tinytest', 'practicalmeteor:chai']);
+  api.use(['ecmascript', 'underscore', 'tinytest', 'practicalmeteor:chai', 'momentjs:moment']);
 
 //   api.addFiles('helpers/fileUploader.tests.js', 'client');
   api.addFiles('helpers/files/files.test.js', 'client');
+  api.addFiles('helpers/impersonation.test.js', 'client');
 
 });

--- a/app/packages/partup-lib/schemas/impersonationrequest.js
+++ b/app/packages/partup-lib/schemas/impersonationrequest.js
@@ -1,0 +1,33 @@
+
+const ImpersonationRequestSchema = new SimpleSchema({
+  _id: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  accepted_at: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+    optional: true,
+  },
+  adminId: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  created_at: {
+    type: Date,
+    defaultValue: new Date(),
+  },
+  status: {
+    type: String,
+    allowedValues: [
+      'pending',
+      'accepted',
+    ],
+  },
+  userId: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
+});
+
+Partup.schemas.entities.impersonationRequest = ImpersonationRequestSchema;

--- a/app/packages/partup-server/collection_hooks.js
+++ b/app/packages/partup-server/collection_hooks.js
@@ -13,14 +13,14 @@ var equal = Npm.require('deeper');
 var basicAfterInsert = function(namespace) {
     return function(userId, document) {
 
-        // If no userId is present, try getting it from the document 
+        // If no userId is present, try getting it from the document
         // Used for User-API access, as no user is specified
-        if (!userId) { 
-            userId = document.creator_id || 
-                     document.upper_id || 
+        if (!userId) {
+            userId = document.creator_id ||
+                     document.upper_id ||
                      get(document, 'type_data.creator._id')
         }
-        
+
         Event.emit(namespace + '.inserted', userId, document);
     };
 };
@@ -36,14 +36,14 @@ var basicAfterInsert = function(namespace) {
 var basicAfterUpdate = function(namespace) {
     return function(userId, document, fieldNames, modifier, options) {
 
-        // If no userId is present, try getting it from the document 
+        // If no userId is present, try getting it from the document
         // Used for User-API access, as no user is specified
-        if (!userId) { 
-            userId = document.creator_id || 
-                     document.upper_id || 
+        if (!userId) {
+            userId = document.creator_id ||
+                     document.upper_id ||
                      get(document, 'type_data.creator._id')
         }
-        
+
         Event.emit(namespace + '.updated', userId, document, this.previous);
 
         if (this.previous) {
@@ -111,3 +111,7 @@ Ratings.after.remove(basicAfterRemove('partups.contributions.ratings'));
 
 // Notifications Events
 Notifications.after.insert(basicAfterInsert('partups.notifications'));
+
+ImpersonationRequests.before.insert((userId, doc) => {
+  doc.created_at = new Date();
+});


### PR DESCRIPTION
In order to comply for `Impersonation in advance profile settings should only show after request by admin` in #1684 the following changes have been made to the impersonation flow:

1. An impersonation request is no longer stored in the key `impersonation` on the `user` object, a new entity called `ImpersonationRequest` is created instead;
1. A request stays valid for 30 minutes, the user must accept before this time or the admin must create a new request;
1. The admin must also start the impersonation within these 30 minutes;
1. An impersonation stays active for 30 minutes starting from the moment the admin starts the impersonation;
1. The admin can impersonate multiple times within the allowed time period;
1. The flow is non-reactive so the admin & user need to refresh after actions.

